### PR TITLE
feat(l4): add delete session action

### DIFF
--- a/src/lazy_take_notes/l4_frameworks_and_drivers/apps/view.py
+++ b/src/lazy_take_notes/l4_frameworks_and_drivers/apps/view.py
@@ -6,11 +6,13 @@ import subprocess  # noqa: S404 -- used for fire-and-forget OS file manager laun
 import sys
 from pathlib import Path
 
+from textual import work
 from textual.app import App as TextualApp
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Horizontal, Vertical
-from textual.widgets import Static
+from textual.screen import ModalScreen
+from textual.widgets import Button, Label, Static
 
 from lazy_take_notes.l4_frameworks_and_drivers.widgets.digest_panel import DigestPanel
 from lazy_take_notes.l4_frameworks_and_drivers.widgets.status_bar import StatusBar
@@ -21,6 +23,53 @@ from lazy_take_notes.l4_frameworks_and_drivers.widgets.transcript_panel import T
 CSS_PATH = 'app.tcss'
 
 
+class DeleteConfirmModal(ModalScreen[bool]):
+    """Confirmation dialog before deleting a session."""
+
+    CSS = """
+    DeleteConfirmModal {
+        align: center middle;
+    }
+    #confirm-box {
+        width: 50;
+        height: auto;
+        padding: 1 2;
+        border: solid $error;
+        background: $surface;
+    }
+    #confirm-buttons { height: auto; }
+    """
+
+    BINDINGS = [
+        Binding('y', 'confirm', 'Delete', show=True),
+        Binding('n', 'cancel_modal', 'Cancel', show=True),
+        Binding('escape', 'cancel_modal', 'Cancel', show=False),
+    ]
+
+    def __init__(self, session_name: str) -> None:
+        super().__init__()
+        self._session_name = session_name
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id='confirm-box'):
+            yield Label(
+                f'Delete session\n[bold]{self._session_name}[/bold]?\nThis cannot be undone.\n[dim]\\[y] Delete  \\[n] Cancel[/dim]',
+                markup=True,
+            )
+            with Horizontal(id='confirm-buttons'):
+                yield Button('Delete', variant='error', id='btn-delete')
+                yield Button('Cancel', id='btn-cancel')
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        self.dismiss(event.button.id == 'btn-delete')
+
+    def action_confirm(self) -> None:
+        self.dismiss(True)
+
+    def action_cancel_modal(self) -> None:
+        self.dismiss(False)
+
+
 class ViewApp(TextualApp):
     """Read-only TUI for browsing a saved session's transcript and digest."""
 
@@ -29,6 +78,7 @@ class ViewApp(TextualApp):
     BINDINGS = [
         Binding('q', 'quit_app', 'Quit', priority=True),
         Binding('o', 'open_session_dir', 'Open', show=False),
+        Binding('d', 'delete_session', 'Delete', show=False),
         Binding('tab', 'focus_next', 'Switch Panel', show=False),
     ]
 
@@ -48,7 +98,7 @@ class ViewApp(TextualApp):
     def on_mount(self) -> None:
         bar = self.query_one('#status-bar', StatusBar)
         bar.mode_label = 'View'
-        bar.keybinding_hints = r'\[c] copy  \[o] open  \[Tab] switch  \[q] back'
+        bar.keybinding_hints = r'\[c] copy  \[o] open  \[d] delete  \[Tab] switch  \[q] back'
 
         # Load transcript — write raw lines directly; the saved file already
         # contains timestamps so we must NOT go through append_segments()
@@ -81,6 +131,16 @@ class ViewApp(TextualApp):
         else:
             opener = 'xdg-open'
         subprocess.Popen([opener, str(self._session_dir)])  # noqa: S603 -- fixed arg list, not shell=True
+
+    @work
+    async def action_delete_session(self) -> None:
+        confirmed = await self.push_screen_wait(
+            DeleteConfirmModal(self._session_dir.name)
+        )
+        if confirmed:
+            import shutil
+            shutil.rmtree(self._session_dir)
+            self.exit()
 
     def action_quit_app(self) -> None:
         self.exit()

--- a/src/lazy_take_notes/l4_frameworks_and_drivers/pickers/session_picker.py
+++ b/src/lazy_take_notes/l4_frameworks_and_drivers/pickers/session_picker.py
@@ -4,11 +4,60 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from textual import work
 from textual.app import App, ComposeResult
 from textual.binding import Binding
 from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.events import Key
-from textual.widgets import Input, ListItem, ListView, Markdown, Static
+from textual.screen import ModalScreen
+from textual.widgets import Button, Input, Label, ListItem, ListView, Markdown, Static
+
+
+class DeleteConfirmModal(ModalScreen[bool]):
+    """Confirmation dialog before deleting a session."""
+
+    CSS = """
+    DeleteConfirmModal {
+        align: center middle;
+    }
+    #confirm-box {
+        width: 50;
+        height: auto;
+        padding: 1 2;
+        border: solid $error;
+        background: $surface;
+    }
+    #confirm-buttons { height: auto; }
+    """
+
+    BINDINGS = [
+        Binding('y', 'confirm', 'Delete', show=True),
+        Binding('n', 'cancel_modal', 'Cancel', show=True),
+        Binding('escape', 'cancel_modal', 'Cancel', show=False),
+    ]
+
+    def __init__(self, session_name: str) -> None:
+        super().__init__()
+        self._session_name = session_name
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id='confirm-box'):
+            yield Label(
+                f'Delete session\n[bold]{self._session_name}[/bold]?\nThis cannot be undone.\n[dim]\\[y] Delete  \\[n] Cancel[/dim]',
+                markup=True,
+            )
+            with Horizontal(id='confirm-buttons'):
+                yield Button('Delete', variant='error', id='btn-delete')
+                yield Button('Cancel', id='btn-cancel')
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        self.dismiss(event.button.id == 'btn-delete')
+
+    def action_confirm(self) -> None:
+        self.dismiss(True)
+
+    def action_cancel_modal(self) -> None:
+        self.dismiss(False)
 
 
 def discover_sessions(sessions_dir: Path) -> list[dict]:
@@ -119,6 +168,7 @@ class SessionPicker(App[Path | None]):
         Binding('escape', 'cancel', 'Cancel', priority=True),
         Binding('q', 'cancel', 'Cancel'),
         Binding('enter', 'select_session', 'Select', priority=True),
+        Binding('d', 'delete_session', 'Delete', show=False),
     ]
 
     def __init__(self, sessions_dir: Path, **kwargs):
@@ -136,7 +186,7 @@ class SessionPicker(App[Path | None]):
                 yield _SessionListView(id='session-list')
             with VerticalScroll(id='session-preview', can_focus=False):
                 yield Markdown('', id='session-preview-md')
-        yield Static('\\[Enter] Select  \\[\u2191/\u2193] Navigate  \\[Esc] Cancel', id='session-footer', markup=True)
+        yield Static('\\[Enter] Select  \\[\u2191/\u2193] Navigate  \\[d] Delete  \\[Esc] Cancel', id='session-footer', markup=True)
 
     def on_mount(self) -> None:
         self._rebuild_list()
@@ -211,6 +261,20 @@ class SessionPicker(App[Path | None]):
         if self._current_session is None:
             return
         self.exit(self._current_session)
+
+    @work
+    async def action_delete_session(self) -> None:
+        if self._current_session is None:
+            return
+        session_dir = self._current_session
+        confirmed = await self.push_screen_wait(
+            DeleteConfirmModal(session_dir.name)
+        )
+        if confirmed:
+            import shutil
+            shutil.rmtree(session_dir)
+            self._sessions = [s for s in self._sessions if s['dir'] != session_dir]
+            self._rebuild_list()
 
     def action_cancel(self) -> None:
         self.exit(None)

--- a/tests/l4_frameworks_and_drivers/apps/test_view_app.py
+++ b/tests/l4_frameworks_and_drivers/apps/test_view_app.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from lazy_take_notes.l4_frameworks_and_drivers.apps.view import ViewApp
+from lazy_take_notes.l4_frameworks_and_drivers.apps.view import DeleteConfirmModal, ViewApp
 from lazy_take_notes.l4_frameworks_and_drivers.widgets.digest_panel import DigestPanel
 from lazy_take_notes.l4_frameworks_and_drivers.widgets.status_bar import StatusBar
 from lazy_take_notes.l4_frameworks_and_drivers.widgets.transcript_panel import TranscriptPanel
@@ -160,3 +160,86 @@ class TestViewAppStatusBar:
             await pilot.pause()
             bar = app.query_one('#status-bar', StatusBar)
             assert 'back' in bar.keybinding_hints
+
+    @pytest.mark.asyncio
+    async def test_status_bar_hints_include_delete(self, tmp_path):
+        session_dir = _make_session(tmp_path)
+        app = ViewApp(session_dir=session_dir)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            bar = app.query_one('#status-bar', StatusBar)
+            assert 'delete' in bar.keybinding_hints
+
+
+class TestDeleteSession:
+    @pytest.mark.asyncio
+    async def test_d_opens_confirm_modal(self, tmp_path):
+        session_dir = _make_session(tmp_path)
+        app = ViewApp(session_dir=session_dir)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await pilot.press('d')
+            await pilot.pause()
+            assert isinstance(app.screen, DeleteConfirmModal)
+
+    @pytest.mark.asyncio
+    async def test_delete_confirmed_removes_dir(self, tmp_path):
+        session_dir = _make_session(tmp_path, transcript='Hello\n', digest='# Notes')
+        app = ViewApp(session_dir=session_dir)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await pilot.press('d')
+            await pilot.pause()
+            # Click the Delete button in the modal
+            await pilot.click('#btn-delete')
+            await pilot.pause()
+        assert not session_dir.exists()
+
+    @pytest.mark.asyncio
+    async def test_delete_cancelled_keeps_dir(self, tmp_path):
+        session_dir = _make_session(tmp_path, transcript='Hello\n', digest='# Notes')
+        app = ViewApp(session_dir=session_dir)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await pilot.press('d')
+            await pilot.pause()
+            # Click the Cancel button in the modal
+            await pilot.click('#btn-cancel')
+            await pilot.pause()
+            assert session_dir.exists()
+
+    @pytest.mark.asyncio
+    async def test_y_confirms_delete(self, tmp_path):
+        session_dir = _make_session(tmp_path, transcript='Hello\n', digest='# Notes')
+        app = ViewApp(session_dir=session_dir)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await pilot.press('d')
+            await pilot.pause()
+            await pilot.press('y')
+            await pilot.pause()
+        assert not session_dir.exists()
+
+    @pytest.mark.asyncio
+    async def test_n_cancels_delete(self, tmp_path):
+        session_dir = _make_session(tmp_path, transcript='Hello\n', digest='# Notes')
+        app = ViewApp(session_dir=session_dir)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await pilot.press('d')
+            await pilot.pause()
+            await pilot.press('n')
+            await pilot.pause()
+            assert session_dir.exists()
+
+    @pytest.mark.asyncio
+    async def test_escape_cancels_delete(self, tmp_path):
+        session_dir = _make_session(tmp_path, transcript='Hello\n', digest='# Notes')
+        app = ViewApp(session_dir=session_dir)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await pilot.press('d')
+            await pilot.pause()
+            await pilot.press('escape')
+            await pilot.pause()
+            assert session_dir.exists()

--- a/tests/l4_frameworks_and_drivers/pickers/test_session_picker.py
+++ b/tests/l4_frameworks_and_drivers/pickers/test_session_picker.py
@@ -6,7 +6,10 @@ from pathlib import Path
 
 import pytest
 
+from textual.widgets import Static
+
 from lazy_take_notes.l4_frameworks_and_drivers.pickers.session_picker import (
+    DeleteConfirmModal,
     SessionPicker,
     discover_sessions,
 )
@@ -203,3 +206,112 @@ class TestSessionPicker:
 
             md = picker.query_one('#session-preview-md', Markdown)
             assert md is not None
+
+
+class TestSessionPickerFooter:
+    @pytest.mark.asyncio
+    async def test_footer_includes_delete_hint(self, tmp_path: Path):
+        _create_session(tmp_path, '2026-02-20_120000')
+        picker = SessionPicker(sessions_dir=tmp_path)
+        async with picker.run_test() as pilot:
+            await pilot.pause()
+            footer = picker.query_one('#session-footer', Static)
+            assert 'Delete' in str(footer.render())
+
+
+class TestDeleteSession:
+    @pytest.mark.asyncio
+    async def test_d_opens_confirm_modal(self, tmp_path: Path):
+        _create_session(tmp_path, '2026-02-20_120000')
+        picker = SessionPicker(sessions_dir=tmp_path)
+        async with picker.run_test() as pilot:
+            await pilot.pause()
+            # Focus the list first (search input has focus by default)
+            await pilot.press('down')
+            await pilot.pause()
+            await pilot.press('d')
+            await pilot.pause()
+            assert isinstance(picker.screen, DeleteConfirmModal)
+
+    @pytest.mark.asyncio
+    async def test_delete_confirmed_removes_dir_and_updates_list(self, tmp_path: Path):
+        session_dir = _create_session(tmp_path, '2026-02-20_120000')
+        picker = SessionPicker(sessions_dir=tmp_path)
+        async with picker.run_test() as pilot:
+            await pilot.pause()
+            await pilot.press('down')
+            await pilot.pause()
+            await pilot.press('d')
+            await pilot.pause()
+            await pilot.click('#btn-delete')
+            await pilot.pause()
+            assert not session_dir.exists()
+            assert picker._sessions == []
+
+    @pytest.mark.asyncio
+    async def test_delete_cancelled_keeps_dir(self, tmp_path: Path):
+        session_dir = _create_session(tmp_path, '2026-02-20_120000')
+        picker = SessionPicker(sessions_dir=tmp_path)
+        async with picker.run_test() as pilot:
+            await pilot.pause()
+            await pilot.press('down')
+            await pilot.pause()
+            await pilot.press('d')
+            await pilot.pause()
+            await pilot.click('#btn-cancel')
+            await pilot.pause()
+            assert session_dir.exists()
+
+    @pytest.mark.asyncio
+    async def test_y_confirms_delete(self, tmp_path: Path):
+        session_dir = _create_session(tmp_path, '2026-02-20_120000')
+        picker = SessionPicker(sessions_dir=tmp_path)
+        async with picker.run_test() as pilot:
+            await pilot.pause()
+            await pilot.press('down')
+            await pilot.pause()
+            await pilot.press('d')
+            await pilot.pause()
+            await pilot.press('y')
+            await pilot.pause()
+            assert not session_dir.exists()
+
+    @pytest.mark.asyncio
+    async def test_n_cancels_delete(self, tmp_path: Path):
+        session_dir = _create_session(tmp_path, '2026-02-20_120000')
+        picker = SessionPicker(sessions_dir=tmp_path)
+        async with picker.run_test() as pilot:
+            await pilot.pause()
+            await pilot.press('down')
+            await pilot.pause()
+            await pilot.press('d')
+            await pilot.pause()
+            await pilot.press('n')
+            await pilot.pause()
+            assert session_dir.exists()
+
+    @pytest.mark.asyncio
+    async def test_escape_cancels_delete(self, tmp_path: Path):
+        session_dir = _create_session(tmp_path, '2026-02-20_120000')
+        picker = SessionPicker(sessions_dir=tmp_path)
+        async with picker.run_test() as pilot:
+            await pilot.pause()
+            await pilot.press('down')
+            await pilot.pause()
+            await pilot.press('d')
+            await pilot.pause()
+            await pilot.press('escape')
+            await pilot.pause()
+            assert session_dir.exists()
+
+    @pytest.mark.asyncio
+    async def test_d_with_no_session_is_noop(self, tmp_path: Path):
+        picker = SessionPicker(sessions_dir=tmp_path)  # empty dir
+        async with picker.run_test() as pilot:
+            await pilot.pause()
+            await pilot.press('down')
+            await pilot.pause()
+            await pilot.press('d')
+            await pilot.pause()
+            # No modal should appear — still on the base screen
+            assert not isinstance(picker.screen, DeleteConfirmModal)


### PR DESCRIPTION

<img width="802" height="345" alt="2026-03-06_10 24 04" src="https://github.com/user-attachments/assets/e31b728a-2938-4ef9-9dd2-59ba7e38664b" />


## Summary
- Add delete action (`d` key) to **ViewApp** and **SessionPicker** with a confirmation modal
- Modal supports keyboard shortcuts: `y` to confirm, `n` or `Escape` to cancel, plus clickable buttons
- In ViewApp, confirming deletion exits back to the session picker
- In SessionPicker, the session list rebuilds in-place after deletion
- Footer/status bar hints updated to show the new `[d] delete` keybinding

## Test plan
- [x] `test_d_opens_confirm_modal` — pressing `d` shows the confirmation modal
- [x] `test_delete_confirmed_removes_dir` — confirming deletes the session directory
- [x] `test_delete_cancelled_keeps_dir` — cancelling preserves the directory
- [x] `test_y_confirms_delete` / `test_n_cancels_delete` / `test_escape_cancels_delete` — keyboard shortcuts work
- [x] `test_status_bar_hints_include_delete` / `test_footer_includes_delete_hint` — UI hints present
- [x] `test_d_with_no_session_is_noop` — no crash when no session is selected
- [x] Full test suite passes (648 tests)