### PR TITLE
App bundle build script

### DIFF
--- a/scripts/build_app_bundle.sh
+++ b/scripts/build_app_bundle.sh
@@ -38,7 +38,18 @@ mkdir -p "$CONTENTS/MacOS" "$CONTENTS/Resources"
 # Note: REPO_ROOT is baked in at build time so the app knows where the project lives.
 cat > "$CONTENTS/MacOS/launcher" << LAUNCHER
 #!/bin/bash
+# Initialize a reasonable PATH (important for Finder launches)
+if [ -x /usr/libexec/path_helper ]; then
+    eval "\$(/usr/libexec/path_helper -s)"
+fi
+
 PROJECT_DIR="$REPO_ROOT"
+
+# Ensure the baked-in project directory still exists
+if [[ ! -d "\$PROJECT_DIR" ]]; then
+    osascript -e 'display dialog "The Lazy Take Notes project directory could not be found:\n\n\$PROJECT_DIR\n\nThis usually means the repository was moved, renamed, or the app bundle was copied from another machine.\n\nRebuild LazyTakeNotes.app from the current repository location, then try again." with title "Lazy Take Notes" buttons {"OK"} default button "OK" with icon stop'
+    exit 1
+fi
 
 # Resolve the uv binary (may not be on PATH when launched from Finder)
 if command -v uv &>/dev/null; then
@@ -47,6 +58,10 @@ elif [ -f "\$HOME/.local/bin/uv" ]; then
     UV="\$HOME/.local/bin/uv"
 elif [ -f "\$HOME/.cargo/bin/uv" ]; then
     UV="\$HOME/.cargo/bin/uv"
+elif [ -f "/opt/homebrew/bin/uv" ]; then
+    UV="/opt/homebrew/bin/uv"
+elif [ -f "/usr/local/bin/uv" ]; then
+    UV="/usr/local/bin/uv"
 else
     osascript -e 'display dialog "uv not found. Install it first:\n\ncurl -LsSf https://astral.sh/uv/install.sh | sh" with title "Lazy Take Notes" buttons {"OK"} default button "OK" with icon stop'
     exit 1
@@ -56,7 +71,7 @@ fi
 osascript <<EOF
 tell application "Terminal"
     activate
-    do script "cd \$PROJECT_DIR && \$UV run lazy-take-notes"
+    do script "cd \"\$PROJECT_DIR\" && \"\$UV\" run lazy-take-notes"
 end tell
 EOF
 LAUNCHER

--- a/scripts/build_app_bundle.sh
+++ b/scripts/build_app_bundle.sh
@@ -35,7 +35,6 @@ rm -rf "$APP_DIR"
 mkdir -p "$CONTENTS/MacOS" "$CONTENTS/Resources"
 
 # --- Launcher script ---
-# Note: REPO_ROOT is baked in at build time so the app knows where the project lives.
 cat > "$CONTENTS/MacOS/launcher" << LAUNCHER
 #!/bin/bash
 # Initialize a reasonable PATH (important for Finder launches)
@@ -43,19 +42,13 @@ if [ -x /usr/libexec/path_helper ]; then
     eval "\$(/usr/libexec/path_helper -s)"
 fi
 
-PROJECT_DIR="$REPO_ROOT"
-
-# Ensure the baked-in project directory still exists
-if [[ ! -d "\$PROJECT_DIR" ]]; then
-    osascript -e 'display dialog "The Lazy Take Notes project directory could not be found:\n\n\$PROJECT_DIR\n\nThis usually means the repository was moved, renamed, or the app bundle was copied from another machine.\n\nRebuild LazyTakeNotes.app from the current repository location, then try again." with title "Lazy Take Notes" buttons {"OK"} default button "OK" with icon stop'
-    exit 1
-fi
-
 # Resolve the uv binary (may not be on PATH when launched from Finder)
 if command -v uv &>/dev/null; then
     UV="uv"
 elif [ -f "\$HOME/.local/bin/uv" ]; then
     UV="\$HOME/.local/bin/uv"
+elif [ -f "\$HOME/.local/share/mise/shims/uv" ]; then
+    UV="\$HOME/.local/share/mise/shims/uv"
 elif [ -f "\$HOME/.cargo/bin/uv" ]; then
     UV="\$HOME/.cargo/bin/uv"
 elif [ -f "/opt/homebrew/bin/uv" ]; then
@@ -67,10 +60,10 @@ else
     exit 1
 fi
 
-# Open a new Terminal window, cd to project, and run the app
+# Open a new Terminal window, use uv tool run from git (no local repo required)
 osascript <<EOF
 tell application "Terminal"
-    do script "cd \"\$PROJECT_DIR\" && \"\$UV\" run lazy-take-notes"
+    do script "mkdir -p ~/Documents/LazyTakeNotes && cd ~/Documents/LazyTakeNotes && \"\$UV\" tool run --from git+https://github.com/CJHwong/lazy-meeting-note.git lazy-take-notes"
     activate
 end tell
 EOF

--- a/scripts/build_app_bundle.sh
+++ b/scripts/build_app_bundle.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Build a macOS .app bundle for lazy-take-notes.
+# The app opens a new Terminal window and runs the TUI via uv.
+# Output: build/LazyTakeNotes.app (can be moved to /Applications)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+APP_NAME="LazyTakeNotes"
+APP_DIR="$REPO_ROOT/build/${APP_NAME}.app"
+CONTENTS="$APP_DIR/Contents"
+VERSION="$(grep '^version' "$REPO_ROOT/pyproject.toml" | head -1 | sed 's/.*"\(.*\)"/\1/')"
+
+echo "Building ${APP_NAME}.app v${VERSION}..."
+
+# Clean previous build
+rm -rf "$APP_DIR"
+mkdir -p "$CONTENTS/MacOS" "$CONTENTS/Resources"
+
+# --- Launcher script ---
+# Note: REPO_ROOT is baked in at build time so the app knows where the project lives.
+cat > "$CONTENTS/MacOS/launcher" << LAUNCHER
+#!/bin/bash
+PROJECT_DIR="$REPO_ROOT"
+
+# Resolve the uv binary (may not be on PATH when launched from Finder)
+if command -v uv &>/dev/null; then
+    UV="uv"
+elif [ -f "\$HOME/.local/bin/uv" ]; then
+    UV="\$HOME/.local/bin/uv"
+elif [ -f "\$HOME/.cargo/bin/uv" ]; then
+    UV="\$HOME/.cargo/bin/uv"
+else
+    osascript -e 'display dialog "uv not found. Install it first:\n\ncurl -LsSf https://astral.sh/uv/install.sh | sh" with title "Lazy Take Notes" buttons {"OK"} default button "OK" with icon stop'
+    exit 1
+fi
+
+# Open a new Terminal window, cd to project, and run the app
+osascript <<EOF
+tell application "Terminal"
+    activate
+    do script "cd \$PROJECT_DIR && \$UV run lazy-take-notes"
+end tell
+EOF
+LAUNCHER
+chmod +x "$CONTENTS/MacOS/launcher"
+
+# --- Info.plist ---
+cat > "$CONTENTS/Info.plist" << PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleExecutable</key>
+    <string>launcher</string>
+    <key>CFBundleName</key>
+    <string>Lazy Take Notes</string>
+    <key>CFBundleDisplayName</key>
+    <string>Lazy Take Notes</string>
+    <key>CFBundleIdentifier</key>
+    <string>com.cjhwong.lazy-take-notes</string>
+    <key>CFBundleVersion</key>
+    <string>${VERSION}</string>
+    <key>CFBundleShortVersionString</key>
+    <string>${VERSION}</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>LSMinimumSystemVersion</key>
+    <string>13.0</string>
+    <key>NSHighResolutionCapable</key>
+    <true/>
+</dict>
+</plist>
+PLIST
+
+echo "Built: $APP_DIR"
+echo ""
+echo "To install:"
+echo "  cp -r $APP_DIR /Applications/"
+echo ""
+echo "Then launch via Spotlight (⌘ Space → 'Lazy Take Notes') or Finder."

--- a/scripts/build_app_bundle.sh
+++ b/scripts/build_app_bundle.sh
@@ -10,7 +10,23 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 APP_NAME="LazyTakeNotes"
 APP_DIR="$REPO_ROOT/build/${APP_NAME}.app"
 CONTENTS="$APP_DIR/Contents"
-VERSION="$(grep '^version' "$REPO_ROOT/pyproject.toml" | head -1 | sed 's/.*"\(.*\)"/\1/')"
+VERSION="$(python3 - <<PY
+import pathlib
+import sys
+import tomllib
+
+pyproject = pathlib.Path("$REPO_ROOT") / "pyproject.toml"
+try:
+    with pyproject.open("rb") as f:
+        data = tomllib.load(f)
+    version = data["project"]["version"]
+except (FileNotFoundError, KeyError) as exc:
+    sys.stderr.write(f"Error reading version from {pyproject}: {exc}\n")
+    sys.exit(1)
+else:
+    print(version, end="")
+PY
+)"
 
 echo "Building ${APP_NAME}.app v${VERSION}..."
 

--- a/scripts/build_app_bundle.sh
+++ b/scripts/build_app_bundle.sh
@@ -70,8 +70,8 @@ fi
 # Open a new Terminal window, cd to project, and run the app
 osascript <<EOF
 tell application "Terminal"
-    activate
     do script "cd \"\$PROJECT_DIR\" && \"\$UV\" run lazy-take-notes"
+    activate
 end tell
 EOF
 LAUNCHER

--- a/tests/scripts/test_build_app_bundle.py
+++ b/tests/scripts/test_build_app_bundle.py
@@ -1,0 +1,56 @@
+"""
+Validate that build_app_bundle.sh produces a launcher with valid bash syntax.
+
+These tests are macOS-only: the script itself uses macOS-specific tools
+(osascript, CoreAudio) and would fail on Linux regardless.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent.parent
+BUILD_SCRIPT = REPO_ROOT / 'scripts' / 'build_app_bundle.sh'
+LAUNCHER = REPO_ROOT / 'build' / 'LazyTakeNotes.app' / 'Contents' / 'MacOS' / 'launcher'
+
+pytestmark = pytest.mark.skipif(
+    sys.platform != 'darwin',
+    reason='app bundle is macOS-only',
+)
+
+
+@pytest.fixture(scope='module')
+def built_launcher():
+    """Run the build script once and yield the launcher path."""
+    result = subprocess.run(  # noqa: S603 -- fixed arg list, not shell=True
+        ['bash', str(BUILD_SCRIPT)],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+    assert result.returncode == 0, f'build_app_bundle.sh failed:\n{result.stderr}'
+    assert LAUNCHER.exists(), 'launcher was not created'
+    return LAUNCHER
+
+
+def test_launcher_bash_syntax(built_launcher):
+    """bash -n must pass — catches missing fi/done/esac in heredoc-generated scripts."""
+    result = subprocess.run(  # noqa: S603 -- fixed arg list, not shell=True
+        ['bash', '-n', str(built_launcher)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, f'launcher has bash syntax errors:\n{result.stderr}'
+
+
+def test_launcher_is_executable(built_launcher):
+    """The launcher must have its executable bit set so macOS can run it."""
+    assert built_launcher.stat().st_mode & 0o111, 'launcher is not executable'
+
+
+def test_launcher_contains_path_helper(built_launcher):
+    """path_helper invocation must be present in the launcher."""
+    source = built_launcher.read_text()
+    assert 'path_helper' in source, 'path_helper invocation missing from launcher'

--- a/tests/scripts/test_build_app_bundle.py
+++ b/tests/scripts/test_build_app_bundle.py
@@ -5,6 +5,7 @@ These tests are macOS-only: the script itself uses macOS-specific tools
 (osascript, CoreAudio) and would fail on Linux regardless.
 """
 
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -23,7 +24,7 @@ pytestmark = pytest.mark.skipif(
 
 @pytest.fixture(scope='module')
 def built_launcher():
-    """Run the build script once and yield the launcher path."""
+    """Run the build script once, yield the launcher path, then remove the artifact."""
     result = subprocess.run(  # noqa: S603 -- fixed arg list, not shell=True
         ['bash', str(BUILD_SCRIPT)],
         capture_output=True,
@@ -32,7 +33,10 @@ def built_launcher():
     )
     assert result.returncode == 0, f'build_app_bundle.sh failed:\n{result.stderr}'
     assert LAUNCHER.exists(), 'launcher was not created'
-    return LAUNCHER
+    yield LAUNCHER
+    app_bundle = REPO_ROOT / 'build' / 'LazyTakeNotes.app'
+    if app_bundle.exists():
+        shutil.rmtree(app_bundle)
 
 
 def test_launcher_bash_syntax(built_launcher):
@@ -54,3 +58,17 @@ def test_launcher_contains_path_helper(built_launcher):
     """path_helper invocation must be present in the launcher."""
     source = built_launcher.read_text()
     assert 'path_helper' in source, 'path_helper invocation missing from launcher'
+
+
+def test_launcher_contains_mise_shim_path(built_launcher):
+    """mise shim path must be present in the uv detection chain."""
+    source = built_launcher.read_text()
+    assert '.local/share/mise/shims/uv' in source
+
+
+def test_launcher_uses_uvx_not_local_run(built_launcher):
+    """Launcher must use uv tool run from git, not local uv run."""
+    source = built_launcher.read_text()
+    assert 'tool run' in source
+    assert 'lazy-meeting-note' in source
+    assert 'PROJECT_DIR' not in source


### PR DESCRIPTION
This pull request introduces a new script to automate building a macOS `.app` bundle for the project, enabling users to easily launch the TUI application from Finder or Spotlight. The script handles creation of the app bundle, sets up a launcher, and configures metadata for macOS integration.

App bundle creation and launcher setup:

* Added `scripts/build_app_bundle.sh` to generate a macOS `.app` bundle (`LazyTakeNotes.app`) that launches the TUI via `uv` in a new Terminal window, including logic to locate the `uv` binary and prompt for installation if missing.

macOS integration:

* The script creates an `Info.plist` file with appropriate metadata (app name, identifier, version, minimum system version, and high-resolution support) for macOS compatibility and proper display in Finder and Spotlight.

User instructions:

* Provides clear instructions for installing the app bundle to `/Applications` and launching it via Spotlight or Finder.