### PR TITLE
fix: replace shell alias with executable script so take-note works immediately

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -45,18 +45,20 @@ else
   ok "Already installed"
 fi
 
-# 4. alias
-section "4 / 5  Shell alias"
-SHELL_RC="$HOME/.zshrc"
-ALIAS_LINE='alias take-note="uvx --from git+https://github.com/CJHwong/lazy-meeting-note.git lazy-take-notes"'
+# 4. take-note command
+section "4 / 5  take-note command"
+BREW_BIN="$(brew --prefix)/bin"
+TAKE_NOTE_BIN="$BREW_BIN/take-note"
 
-if grep -q "alias take-note=" "$SHELL_RC" 2>/dev/null; then
-  ok "Already set in $SHELL_RC"
+if [ -f "$TAKE_NOTE_BIN" ]; then
+  ok "Already exists at $TAKE_NOTE_BIN"
 else
-  echo "" >> "$SHELL_RC"
-  echo "# lazy-take-notes" >> "$SHELL_RC"
-  echo "$ALIAS_LINE" >> "$SHELL_RC"
-  ok "Added 'take-note' alias to $SHELL_RC"
+  cat > "$TAKE_NOTE_BIN" << EOF
+#!/bin/bash
+exec "$BREW_BIN/uvx" --from git+https://github.com/CJHwong/lazy-meeting-note.git lazy-take-notes "\$@"
+EOF
+  chmod +x "$TAKE_NOTE_BIN"
+  ok "Created 'take-note' command at $TAKE_NOTE_BIN"
 fi
 
 # 5. config.yaml
@@ -83,5 +85,5 @@ echo -e "Sign in to Ollama to enable cloud models:\n"
 ollama signin
 
 echo -e "\n${GREEN}${BOLD}Setup complete!${RESET}"
-echo -e "Open a new terminal window and run:\n"
+echo -e "Run:\n"
 echo -e "  ${BOLD}take-note record${RESET}\n"


### PR DESCRIPTION
## Problem

The setup script was writing an alias to `~/.zshrc`, but this had three bugs:

1. **Alias never active in the same session** — the script runs under `bash` (`curl | bash`), so the alias was added to `.zshrc` but never sourced. Users had to open a new terminal.
2. **`uvx` not found after opening new terminal** — the alias expanded correctly, but `uvx` (installed by Homebrew) may not be in PATH yet, causing `command not found: uvx`.
3. **Only `.zshrc` patched** — bash/fish users were completely unaffected.

## Fix

Write a real executable script to `$(brew --prefix)/bin/take-note` (e.g. `/opt/homebrew/bin/take-note` on Apple Silicon). This path is always in `$PATH` on macOS thanks to Homebrew, works with every shell, and the `uvx` path is hardcoded at install time so there are no PATH resolution issues.

The user can now run `take-note record` immediately in the same terminal — no new window required.

## Test

```bash
curl -fsSL https://raw.githubusercontent.com/kjohh/lazy-take-notes/fix/shell-alias-not-working/setup.sh | bash
# in the same terminal:
take-note record
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)