### PR TITLE
fix: resolve uvx path at install time and clean up stale aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,13 @@ Run this in Terminal — it installs everything and sets up a `take-note` shortc
 curl -fsSL https://raw.githubusercontent.com/CJHwong/lazy-take-notes/main/setup.sh | bash
 ```
 
-Then open a new terminal window and run `take-note record`.
+Then run `take-note record`.
 
 ### Manual install
 
 ```bash
 # try without installing (uv required)
-uvx --from git+https://github.com/CJHwong/lazy-meeting-note.git lazy-take-notes
+uvx --from git+https://github.com/CJHwong/lazy-take-notes.git lazy-take-notes
 
 # or clone and install locally
 uv sync

--- a/setup.sh
+++ b/setup.sh
@@ -50,12 +50,29 @@ section "4 / 5  take-note command"
 BREW_BIN="$(brew --prefix)/bin"
 TAKE_NOTE_BIN="$BREW_BIN/take-note"
 
+# Clean up stale alias from previous setup versions
+SHELL_RC="$HOME/.zshrc"
+if grep -q "alias take-note=" "$SHELL_RC" 2>/dev/null; then
+  sed -i '' '/# lazy-take-notes/d;/alias take-note=/d' "$SHELL_RC"
+  info "Removed old alias from $SHELL_RC"
+fi
+
+UVX_PATH="$(command -v uvx 2>/dev/null)"
+if [ -z "$UVX_PATH" ]; then
+  echo -e "  ${YELLOW}⚠${RESET}  uvx not found in PATH — install uv first"
+  exit 1
+fi
+
 if [ -f "$TAKE_NOTE_BIN" ]; then
   ok "Already exists at $TAKE_NOTE_BIN"
 else
+  if ! touch "$TAKE_NOTE_BIN" 2>/dev/null; then
+    echo -e "  ${YELLOW}⚠${RESET}  Cannot write to $BREW_BIN — re-run with: sudo bash setup.sh"
+    exit 1
+  fi
   cat > "$TAKE_NOTE_BIN" << EOF
-#!/bin/bash
-exec "$BREW_BIN/uvx" --from git+https://github.com/CJHwong/lazy-meeting-note.git lazy-take-notes "\$@"
+#!/bin/zsh
+exec "$UVX_PATH" --from git+https://github.com/CJHwong/lazy-take-notes.git lazy-take-notes "\$@"
 EOF
   chmod +x "$TAKE_NOTE_BIN"
   ok "Created 'take-note' command at $TAKE_NOTE_BIN"


### PR DESCRIPTION
## Summary
Follow-up to #13 — fixes issues found during review and testing:

- **uvx not found**: the generated script hardcoded `$BREW_BIN/uvx`, but uvx may be installed by mise/pipx/standalone — now resolved at install time via `command -v uvx`
- **Old alias shadows executable**: existing users who ran the previous setup have `alias take-note=` in `.zshrc`, which takes precedence over the new executable — now cleaned up on re-run
- **Stale repo URL**: `lazy-meeting-note` → `lazy-take-notes` in both setup.sh and README
- **Shebang**: `#!/bin/bash` → `#!/bin/zsh` in generated script (macOS default shell)
- **Write permission check**: fail early with clear message if brew bin isn't writable
- **README**: removed "open a new terminal" instruction (no longer needed)

## Test plan
- [x] Ran `setup.sh` on macOS (Apple Silicon) with uvx installed via mise
- [x] Verified `take-note view` works immediately in the same terminal
- [x] Verified old alias cleanup logic with grep