### PR TITLE
refactor(cli): extract resolve_base_dir helper and improve defaults

### DIFF
--- a/src/lazy_take_notes/l4_frameworks_and_drivers/cli.py
+++ b/src/lazy_take_notes/l4_frameworks_and_drivers/cli.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import sys
 from importlib.metadata import entry_points
 from pathlib import Path
@@ -20,6 +21,9 @@ from lazy_take_notes.l4_frameworks_and_drivers.cli_helpers import (
 )
 from lazy_take_notes.l4_frameworks_and_drivers.cli_helpers import (
     preflight_llm as _preflight_llm,
+)
+from lazy_take_notes.l4_frameworks_and_drivers.cli_helpers import (
+    resolve_base_dir as _resolve_base_dir,
 )
 from lazy_take_notes.l4_frameworks_and_drivers.cli_helpers import (
     run_transcribe as _run_transcribe,
@@ -58,6 +62,7 @@ def _pre_init_resource_tracker() -> None:  # pragma: no cover -- best-effort pla
     '--output-dir',
     default=None,
     type=click.Path(),
+    envvar='LTN_OUTPUT_DIR',
     help='Base output directory (session subfolder created automatically).',
 )
 @click.version_option(version=__version__)
@@ -77,14 +82,17 @@ def cli(ctx, config_path, output_dir):
         WelcomePicker,
     )
 
+    kiosk = os.environ.get('LTN_KIOSK') == '1'
     while True:
         mode = WelcomePicker().run()
         if mode == 'record':
             ctx.invoke(record)
-            return
+            if not kiosk:
+                return
         elif mode == 'transcribe':
             ctx.invoke(transcribe)
-            return
+            if not kiosk:
+                return
         elif mode == 'view':
             ctx.invoke(view)
         elif mode == 'create-template':
@@ -113,7 +121,7 @@ def record(ctx, label):
     if template is None:
         return
 
-    base_dir = Path(output_dir or config.output.directory)
+    base_dir = _resolve_base_dir(output_dir, config)
     out_dir = _make_session_dir(base_dir, label)
 
     missing_digest, missing_interactive = _preflight_llm(infra, config)
@@ -176,7 +184,7 @@ def view(ctx):
     output_dir = ctx.obj['output_dir']
     config, _infra, _template_loader = _load_config(config_path, output_dir)
 
-    base_dir = Path(output_dir or config.output.directory)
+    base_dir = _resolve_base_dir(output_dir, config)
 
     from lazy_take_notes.l4_frameworks_and_drivers.apps.view import (  # noqa: PLC0415 -- deferred: Textual TUI not loaded for --help
         ViewApp,

--- a/src/lazy_take_notes/l4_frameworks_and_drivers/cli_helpers.py
+++ b/src/lazy_take_notes/l4_frameworks_and_drivers/cli_helpers.py
@@ -18,6 +18,11 @@ if TYPE_CHECKING:
     from lazy_take_notes.l1_entities.transcript import TranscriptSegment
 
 
+def resolve_base_dir(output_dir: str | None, config) -> Path:
+    """Resolve the base output directory, expanding ~ in paths."""
+    return Path(output_dir or config.output.directory).expanduser()
+
+
 def make_session_dir(base_dir: Path, label: str | None) -> Path:
     """Create a timestamped session subdirectory under base_dir."""
     stamp = datetime.now().strftime('%Y-%m-%d_%H%M%S')
@@ -156,7 +161,7 @@ def run_transcribe(
     if template is None:
         return
 
-    base_dir = Path(output_dir or config.output.directory)
+    base_dir = resolve_base_dir(output_dir, config)
     out_dir = make_session_dir(base_dir, label)
 
     missing_digest, missing_interactive = preflight_llm(infra, config)

--- a/src/lazy_take_notes/l4_frameworks_and_drivers/pickers/file_picker.py
+++ b/src/lazy_take_notes/l4_frameworks_and_drivers/pickers/file_picker.py
@@ -104,7 +104,7 @@ class FilePicker(SearchablePicker[Path]):
 
     def __init__(self, start_dir: Path | None = None, audio_exts: frozenset[str] = AUDIO_EXTS, **kwargs) -> None:
         super().__init__(**kwargs)
-        self._current_dir = (start_dir or Path.cwd()).resolve()
+        self._current_dir = (start_dir or Path.home()).resolve()
         self._audio_exts = audio_exts
         self._highlighted_dir: Path | None = None
 

--- a/src/lazy_take_notes/l4_frameworks_and_drivers/workers/audio_worker.py
+++ b/src/lazy_take_notes/l4_frameworks_and_drivers/workers/audio_worker.py
@@ -339,7 +339,7 @@ def run_audio_worker(
     if proc_rec_writer is not None:
         proc_rec_writer.join(timeout=5)
 
-    _executor.shutdown(wait=True)
+    _executor.shutdown(wait=False, cancel_futures=True)
 
     # Release transcriber resources (suppresses C-level teardown noise)
     transcriber.close()


### PR DESCRIPTION
## Reason

`output_dir` paths with `~` never expanded, FilePicker defaulted to cwd (broken in bundled apps), and executor shutdown blocked forever on stuck futures.

## Changes

1. **cli_helpers.py**: Extract `resolve_base_dir()` with `expanduser()`, replacing 3 duplicate inline expressions
2. **cli.py**: Add `envvar='LTN_OUTPUT_DIR'` to `--output-dir` Click option; add `LTN_KIOSK` env var for welcome picker loop
3. **file_picker.py**: Default to `Path.home()` instead of `Path.cwd()`
4. **audio_worker.py**: `shutdown(wait=False, cancel_futures=True)` since explicit flush already drains futures

## Test Scope

- 836 tests pass, zero failures
- No new tests needed (behavioral improvements to existing code paths)

## Checks

- [x] Keep pull requests small so they can be easily reviewed