### PR TITLE
feat(l4): built-in templates notice and show_builtins toggle

### DIFF
--- a/src/lazy_take_notes/l3_interface_adapters/gateways/paths.py
+++ b/src/lazy_take_notes/l3_interface_adapters/gateways/paths.py
@@ -8,6 +8,7 @@ CONFIG_DIR = user_config_path('lazy-take-notes')
 USER_TEMPLATES_DIR = CONFIG_DIR / 'templates'
 
 CONSENT_NOTICED_PATH = CONFIG_DIR / '.consent_noticed'
+BUILTIN_TEMPLATES_NOTICED_PATH = CONFIG_DIR / '.builtin_templates_noticed'
 
 PLUGINS_YAML = CONFIG_DIR / 'plugins.yaml'
 PLUGINS_TXT = CONFIG_DIR / 'plugins.txt'

--- a/src/lazy_take_notes/l4_frameworks_and_drivers/apps/config.py
+++ b/src/lazy_take_notes/l4_frameworks_and_drivers/apps/config.py
@@ -590,6 +590,15 @@ class ConfigApp(TextualApp):
                             placeholder='100000',
                         )
 
+                    with Vertical(classes='field-group'):
+                        yield Static('Templates', classes='field-group-title')
+                        yield _SwitchRow(
+                            'Show Built-in Templates',
+                            'cfg-show-builtin-templates',
+                            self._infra.show_builtin_templates,
+                            help_text='Show bundled example templates in the picker. Disable to see only your own.',
+                        )
+
             # ── Tab 4: Output ────────────────────────────────────────
             with TabPane('Output', id='tab-output'):
                 with VerticalScroll(classes='form-scroll'):
@@ -689,6 +698,7 @@ class ConfigApp(TextualApp):
             'llm_provider': provider,
             'transcription_provider': str(trans_provider),
             'theme': str(self.query_one('#cfg-theme', Select).value),
+            'show_builtin_templates': self.query_one('#cfg-show-builtin-templates', Switch).value,
             'ollama': {
                 'host': self.query_one('#cfg-ollama-host', Input).value.strip(),
             },

--- a/src/lazy_take_notes/l4_frameworks_and_drivers/apps/template_builder.py
+++ b/src/lazy_take_notes/l4_frameworks_and_drivers/apps/template_builder.py
@@ -231,6 +231,11 @@ class TemplateBuilderApp(TextualApp):
         )
 
     def on_mount(self) -> None:
+        from lazy_take_notes.l4_frameworks_and_drivers.config import (  # noqa: PLC0415 -- deferred: avoid import at module level
+            load_theme,
+        )
+
+        self.theme = load_theme()
         self._append_chat('assistant', _WELCOME)
         self.query_one('#tb-input', Input).focus()
 

--- a/src/lazy_take_notes/l4_frameworks_and_drivers/cli_helpers.py
+++ b/src/lazy_take_notes/l4_frameworks_and_drivers/cli_helpers.py
@@ -80,7 +80,7 @@ def load_config(config_path, output_dir):
     return config, infra, template_loader
 
 
-def pick_template(template_loader):
+def pick_template(template_loader, *, show_builtins: bool = True):
     """Show the interactive template picker. Returns a SessionTemplate, or None if cancelled.
 
     Handles the create-template loop internally — if the user presses [n] to
@@ -97,7 +97,7 @@ def pick_template(template_loader):
     # pickers and main apps, eliminating inter-app terminal flicker entirely.
     _clear_normal_screen()
     while True:
-        picker_result = TemplatePicker().run()
+        picker_result = TemplatePicker(show_builtins=show_builtins).run()
         if picker_result is None:
             return None
         if picker_result == '__create_template__':
@@ -168,7 +168,7 @@ def run_transcribe(
     output_dir = ctx.obj['output_dir']
     config, infra, template_loader = load_config(config_path, output_dir)
 
-    template = pick_template(template_loader)
+    template = pick_template(template_loader, show_builtins=infra.show_builtin_templates)
     if template is None:
         return
 
@@ -245,7 +245,7 @@ def run_record(
     output_dir = ctx.obj['output_dir']
     config, infra, template_loader = load_config(config_path, output_dir)
 
-    template = pick_template(template_loader)
+    template = pick_template(template_loader, show_builtins=infra.show_builtin_templates)
     if template is None:
         return
 

--- a/src/lazy_take_notes/l4_frameworks_and_drivers/config.py
+++ b/src/lazy_take_notes/l4_frameworks_and_drivers/config.py
@@ -86,6 +86,7 @@ class InfraConfig(BaseModel):
     llm_provider: str = 'ollama'  # 'ollama' | 'openai' | plugin-registered name
     transcription_provider: str = 'whisper-cpp'
     theme: str = 'textual-dark'  # Textual built-in theme name
+    show_builtin_templates: bool = True
     ollama: OllamaProviderConfig = Field(default_factory=OllamaProviderConfig)
     openai: OpenAIProviderConfig = Field(default_factory=OpenAIProviderConfig)
 

--- a/src/lazy_take_notes/l4_frameworks_and_drivers/pickers/template_picker.py
+++ b/src/lazy_take_notes/l4_frameworks_and_drivers/pickers/template_picker.py
@@ -16,6 +16,7 @@ from textual.screen import ModalScreen
 from textual.widgets import Button, Input, ListItem, Markdown, Static
 
 from lazy_take_notes.l1_entities.template import SessionTemplate
+from lazy_take_notes.l3_interface_adapters.gateways.paths import BUILTIN_TEMPLATES_NOTICED_PATH
 from lazy_take_notes.l3_interface_adapters.gateways.yaml_template_loader import (
     YamlTemplateLoader,
     all_template_names,
@@ -27,6 +28,9 @@ from lazy_take_notes.l3_interface_adapters.gateways.yaml_template_loader import 
 from lazy_take_notes.l4_frameworks_and_drivers.pickers.base import (
     PickerListView,
     SearchablePicker,
+)
+from lazy_take_notes.l4_frameworks_and_drivers.widgets.builtin_templates_notice import (
+    BuiltinTemplatesNotice,
 )
 
 
@@ -149,16 +153,34 @@ class TemplatePicker(SearchablePicker[str]):
     #sp-list-pane { max-width: 40; }
     """
 
-    def __init__(self, **kwargs):
+    def __init__(self, *, show_builtins: bool = True, **kwargs):
         super().__init__(**kwargs)
         loader = YamlTemplateLoader()
         self._user_names = user_template_names()
-        self._templates: dict[str, SessionTemplate] = {name: loader.load(name) for name in sorted(all_template_names())}
+        self._builtin_names = builtin_names()
+        self._show_builtins = show_builtins
+
+        all_names = sorted(all_template_names())
+        if not show_builtins:
+            all_names = [n for n in all_names if n in self._user_names or n not in self._builtin_names]
+
+        self._templates: dict[str, SessionTemplate] = {name: loader.load(name) for name in all_names}
         self._current_name: str | None = None
         # Set after [e] edit — cleared on AppFocus reload so GUI editors
         # (which return from subprocess.run immediately) get a second reload
         # when the user switches back to the terminal.
         self._pending_reload_name: str | None = None
+
+    def on_mount(self) -> None:  # noqa: D102 -- base class has the docstring; Textual dispatches both via MRO
+        if not BUILTIN_TEMPLATES_NOTICED_PATH.exists():
+            self.push_screen(
+                BuiltinTemplatesNotice(on_suppress=self._suppress_builtin_notice),
+            )
+
+    def _suppress_builtin_notice(self) -> None:
+        """Write flag file so the notice is not shown again."""
+        BUILTIN_TEMPLATES_NOTICED_PATH.parent.mkdir(parents=True, exist_ok=True)
+        BUILTIN_TEMPLATES_NOTICED_PATH.touch()
 
     def _make_list_view(self) -> _TemplateListView:
         return _TemplateListView(id='sp-list')
@@ -341,6 +363,12 @@ class TemplatePicker(SearchablePicker[str]):
                 break
 
     def action_select_item(self) -> None:
+        if len(self.screen_stack) > 1:
+            # Modal is active — don't let priority enter binding leak through.
+            # Dismiss the notice if it's showing; leave other modals alone.
+            if isinstance(self.screen, BuiltinTemplatesNotice):
+                self.screen.dismiss()
+            return
         if self._current_name is None:
             return
         self.exit(self._current_name)

--- a/src/lazy_take_notes/l4_frameworks_and_drivers/widgets/builtin_templates_notice.py
+++ b/src/lazy_take_notes/l4_frameworks_and_drivers/widgets/builtin_templates_notice.py
@@ -1,0 +1,83 @@
+"""Built-in templates notice -- shown in the template picker until dismissed."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from textual.app import ComposeResult
+from textual.containers import VerticalScroll
+from textual.screen import ModalScreen
+from textual.widgets import Markdown, Static
+
+NOTICE_BODY = """\
+Built-in templates are **example sessions** for common use cases \
+(meetings, standups, lectures, podcasts, etc.).
+
+- Press **[n]** in the picker to **create your own** template.
+- To hide built-in templates, set `show_builtin_templates: false` \
+in settings or config.yaml.
+"""
+
+
+class BuiltinTemplatesNotice(ModalScreen[None]):
+    """Non-blocking notice explaining built-in templates. Shown until user opts out."""
+
+    DEFAULT_CSS = """
+    BuiltinTemplatesNotice {
+        align: center middle;
+    }
+
+    BuiltinTemplatesNotice > VerticalScroll {
+        width: 60%;
+        max-width: 72;
+        height: auto;
+        max-height: 60%;
+        background: $surface;
+        border: thick $accent;
+        padding: 1 2;
+    }
+
+    BuiltinTemplatesNotice > VerticalScroll > #btn-title {
+        text-style: bold;
+        color: $accent;
+        margin-bottom: 1;
+    }
+
+    BuiltinTemplatesNotice > VerticalScroll > #btn-body {
+        height: auto;
+    }
+
+    BuiltinTemplatesNotice > VerticalScroll > #btn-hint {
+        dock: bottom;
+        text-align: center;
+        color: $text-muted;
+        margin-top: 1;
+    }
+    """
+
+    BINDINGS = [
+        ('escape', 'dismiss', 'Close'),
+    ]
+
+    def __init__(
+        self,
+        *args,
+        on_suppress: Callable[[], None] | None = None,
+        **kwargs,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self._on_suppress = on_suppress
+
+    def compose(self) -> ComposeResult:
+        with VerticalScroll():
+            yield Static('Built-in Templates', id='btn-title')
+            yield Markdown(NOTICE_BODY, id='btn-body')
+            yield Static(
+                "Press any key to dismiss \u00b7 \\[d] don't show again",
+                id='btn-hint',
+            )
+
+    def on_key(self, event) -> None:  # noqa: ANN001 -- Textual Key event; type not needed
+        if event.key == 'd' and self._on_suppress is not None:
+            self._on_suppress()
+        self.dismiss()

--- a/tests/l4_frameworks_and_drivers/pickers/test_template_picker.py
+++ b/tests/l4_frameworks_and_drivers/pickers/test_template_picker.py
@@ -10,17 +10,29 @@ import pytest
 from textual.widgets import Input, ListView, Markdown
 
 import lazy_take_notes.l3_interface_adapters.gateways.yaml_template_loader as yaml_loader_mod
-from lazy_take_notes.l3_interface_adapters.gateways.yaml_template_loader import all_template_names
+import lazy_take_notes.l4_frameworks_and_drivers.pickers.template_picker as tp_mod
+from lazy_take_notes.l3_interface_adapters.gateways.yaml_template_loader import (
+    all_template_names,
+)
 from lazy_take_notes.l4_frameworks_and_drivers.pickers.template_picker import (
     TemplatePicker,
     resolve_editor,
+)
+from lazy_take_notes.l4_frameworks_and_drivers.widgets.builtin_templates_notice import (
+    BuiltinTemplatesNotice,
 )
 
 
 @pytest.fixture(autouse=True)
 def _isolate_user_templates(monkeypatch):
-    """Ensure user templates dir does not exist so only built-ins show."""
+    """Ensure user templates dir does not exist so only built-ins show.
+
+    Also suppress the built-in templates notice by pointing the flag path
+    to an existing file so the modal is not pushed in every test.
+    """
     monkeypatch.setattr(yaml_loader_mod, 'USER_TEMPLATES_DIR', Path('/nonexistent/user/templates'))
+    # __file__ always exists — cheap way to satisfy BUILTIN_TEMPLATES_NOTICED_PATH.exists()
+    monkeypatch.setattr(tp_mod, 'BUILTIN_TEMPLATES_NOTICED_PATH', Path(__file__))
 
 
 class TestTemplatePicker:
@@ -673,3 +685,119 @@ class TestEditTemplateKeyAndSuspend:
             picker.action_edit_template()
             # Pending reload should NOT be set (early return)
             assert picker._pending_reload_name is None
+
+
+class TestShowBuiltins:
+    @pytest.mark.asyncio
+    async def test_show_builtins_true_includes_all(self):
+        """Default show_builtins=True shows all built-in templates."""
+        picker = TemplatePicker(show_builtins=True)
+        async with picker.run_test():
+            items = picker.query('#sp-list TemplateItem')
+            assert len(items) == len(all_template_names())
+
+    @pytest.mark.asyncio
+    async def test_show_builtins_false_hides_builtins(self):
+        """show_builtins=False removes built-in-only templates from the list."""
+        picker = TemplatePicker(show_builtins=False)
+        async with picker.run_test():
+            items = picker.query('#sp-list TemplateItem')
+            # No user templates in this fixture, so the list should be empty
+            assert len(items) == 0
+
+    @pytest.mark.asyncio
+    async def test_show_builtins_false_keeps_user_templates(self, tmp_path: Path, monkeypatch):
+        """show_builtins=False still shows user templates."""
+        monkeypatch.setattr(yaml_loader_mod, 'USER_TEMPLATES_DIR', tmp_path)
+        (tmp_path / 'my_custom.yaml').write_text(_USER_TEMPLATE_YAML, encoding='utf-8')
+
+        picker = TemplatePicker(show_builtins=False)
+        async with picker.run_test():
+            items = picker.query('#sp-list TemplateItem')
+            assert len(items) == 1
+
+            from lazy_take_notes.l4_frameworks_and_drivers.pickers.template_picker import TemplateItem
+
+            first = items[0]
+            assert isinstance(first, TemplateItem)
+            assert first.template_name == 'my_custom'
+
+    @pytest.mark.asyncio
+    async def test_show_builtins_false_user_override_of_builtin_still_shown(
+        self,
+        tmp_path: Path,
+        monkeypatch,
+    ):
+        """A user override of a built-in name is shown even with show_builtins=False."""
+        monkeypatch.setattr(yaml_loader_mod, 'USER_TEMPLATES_DIR', tmp_path)
+        override = _USER_TEMPLATE_YAML.replace('my_custom', 'OVERRIDDEN').replace('en-US', 'en')
+        (tmp_path / 'default_en.yaml').write_text(override, encoding='utf-8')
+
+        picker = TemplatePicker(show_builtins=False)
+        async with picker.run_test():
+            assert 'default_en' in picker._templates
+            # It's a user template, so it should appear
+            from lazy_take_notes.l4_frameworks_and_drivers.pickers.template_picker import TemplateItem
+
+            items = picker.query('#sp-list TemplateItem')
+            names = [i.template_name for i in items if isinstance(i, TemplateItem)]
+            assert 'default_en' in names
+
+
+class TestBuiltinTemplatesNoticeIntegration:
+    @pytest.mark.asyncio
+    async def test_notice_shown_when_flag_missing(self, tmp_path: Path, monkeypatch):
+        """The notice modal is pushed on mount when the flag file does not exist."""
+        flag = tmp_path / '.builtin_templates_noticed'
+        # Do NOT create the flag file
+        monkeypatch.setattr(tp_mod, 'BUILTIN_TEMPLATES_NOTICED_PATH', flag)
+
+        picker = TemplatePicker()
+        async with picker.run_test() as pilot:
+            await pilot.pause()
+            assert isinstance(picker.screen, BuiltinTemplatesNotice)
+
+    @pytest.mark.asyncio
+    async def test_notice_not_shown_when_flag_exists(self, tmp_path: Path, monkeypatch):
+        """The notice modal is NOT pushed when the flag file exists."""
+        flag = tmp_path / '.builtin_templates_noticed'
+        flag.touch()
+        monkeypatch.setattr(tp_mod, 'BUILTIN_TEMPLATES_NOTICED_PATH', flag)
+
+        picker = TemplatePicker()
+        async with picker.run_test() as pilot:
+            await pilot.pause()
+            assert not isinstance(picker.screen, BuiltinTemplatesNotice)
+
+    @pytest.mark.asyncio
+    async def test_suppress_creates_flag_file(self, tmp_path: Path, monkeypatch):
+        """Pressing 'd' in the notice writes the flag file."""
+        flag = tmp_path / '.builtin_templates_noticed'
+        monkeypatch.setattr(tp_mod, 'BUILTIN_TEMPLATES_NOTICED_PATH', flag)
+
+        picker = TemplatePicker()
+        async with picker.run_test() as pilot:
+            await pilot.pause()
+            assert isinstance(picker.screen, BuiltinTemplatesNotice)
+            assert not flag.exists()
+
+            await pilot.press('d')
+            await pilot.pause()
+            assert flag.exists()
+            assert not isinstance(picker.screen, BuiltinTemplatesNotice)
+
+    @pytest.mark.asyncio
+    async def test_dismiss_without_suppress_no_flag(self, tmp_path: Path, monkeypatch):
+        """Pressing any other key dismisses the notice without writing the flag."""
+        flag = tmp_path / '.builtin_templates_noticed'
+        monkeypatch.setattr(tp_mod, 'BUILTIN_TEMPLATES_NOTICED_PATH', flag)
+
+        picker = TemplatePicker()
+        async with picker.run_test() as pilot:
+            await pilot.pause()
+            assert isinstance(picker.screen, BuiltinTemplatesNotice)
+
+            await pilot.press('enter')
+            await pilot.pause()
+            assert not flag.exists()
+            assert not isinstance(picker.screen, BuiltinTemplatesNotice)

--- a/tests/l4_frameworks_and_drivers/widgets/test_builtin_templates_notice.py
+++ b/tests/l4_frameworks_and_drivers/widgets/test_builtin_templates_notice.py
@@ -1,0 +1,105 @@
+"""Tests for the built-in templates notice modal widget."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from textual.app import App, ComposeResult
+from textual.widgets import Static
+
+from lazy_take_notes.l4_frameworks_and_drivers.widgets.builtin_templates_notice import (
+    NOTICE_BODY,
+    BuiltinTemplatesNotice,
+)
+
+
+class ModalHost(App[None]):
+    """Minimal app to host the notice for testing."""
+
+    def compose(self) -> ComposeResult:
+        yield Static('host')
+
+
+class TestBuiltinTemplatesNotice:
+    @pytest.mark.asyncio
+    async def test_composes_with_title_body_and_hint(self):
+        app = ModalHost()
+        async with app.run_test() as pilot:
+            modal = BuiltinTemplatesNotice()
+            app.push_screen(modal)
+            await pilot.pause()
+
+            assert modal.query_one('#btn-title', Static) is not None
+            assert modal.query_one('#btn-hint', Static) is not None
+
+    @pytest.mark.asyncio
+    async def test_dismiss_on_escape(self):
+        app = ModalHost()
+        async with app.run_test() as pilot:
+            app.push_screen(BuiltinTemplatesNotice())
+            await pilot.pause()
+            assert isinstance(app.screen, BuiltinTemplatesNotice)
+
+            await pilot.press('escape')
+            await pilot.pause()
+            assert not isinstance(app.screen, BuiltinTemplatesNotice)
+
+    @pytest.mark.asyncio
+    async def test_dismiss_on_any_key(self):
+        app = ModalHost()
+        async with app.run_test() as pilot:
+            app.push_screen(BuiltinTemplatesNotice())
+            await pilot.pause()
+            assert isinstance(app.screen, BuiltinTemplatesNotice)
+
+            await pilot.press('enter')
+            await pilot.pause()
+            assert not isinstance(app.screen, BuiltinTemplatesNotice)
+
+    @pytest.mark.asyncio
+    async def test_body_mentions_templates_and_settings(self):
+        assert 'example sessions' in NOTICE_BODY.lower()
+        assert 'show_builtin_templates' in NOTICE_BODY
+        assert '[n]' in NOTICE_BODY
+
+    @pytest.mark.asyncio
+    async def test_d_key_calls_on_suppress_and_dismisses(self):
+        app = ModalHost()
+        async with app.run_test() as pilot:
+            callback = MagicMock()
+            app.push_screen(BuiltinTemplatesNotice(on_suppress=callback))
+            await pilot.pause()
+            assert isinstance(app.screen, BuiltinTemplatesNotice)
+
+            await pilot.press('d')
+            await pilot.pause()
+            callback.assert_called_once()
+            assert not isinstance(app.screen, BuiltinTemplatesNotice)
+
+    @pytest.mark.asyncio
+    async def test_other_key_does_not_call_on_suppress(self):
+        app = ModalHost()
+        async with app.run_test() as pilot:
+            callback = MagicMock()
+            app.push_screen(BuiltinTemplatesNotice(on_suppress=callback))
+            await pilot.pause()
+            assert isinstance(app.screen, BuiltinTemplatesNotice)
+
+            await pilot.press('enter')
+            await pilot.pause()
+            callback.assert_not_called()
+            assert not isinstance(app.screen, BuiltinTemplatesNotice)
+
+    @pytest.mark.asyncio
+    async def test_d_key_without_callback_dismisses_safely(self):
+        """Pressing 'd' when no on_suppress callback is set should still dismiss."""
+        app = ModalHost()
+        async with app.run_test() as pilot:
+            app.push_screen(BuiltinTemplatesNotice())
+            await pilot.pause()
+            assert isinstance(app.screen, BuiltinTemplatesNotice)
+
+            await pilot.press('d')
+            await pilot.pause()
+            assert not isinstance(app.screen, BuiltinTemplatesNotice)


### PR DESCRIPTION
## Reason

Built-in templates clutter the picker for users who only use custom ones, and first-time users have no context on what they are or how to create their own. Closes #26.

## Changes

1. **BuiltinTemplatesNotice** (`widgets/builtin_templates_notice.py`): New modal shown in template picker explaining built-ins, `[d]` to suppress permanently
2. **TemplatePicker** (`pickers/template_picker.py`): `show_builtins` param filters built-in templates; `action_select_item` guards against enter leaking through modal
3. **InfraConfig** (`config.py`): New `show_builtin_templates` bool (default true)
4. **ConfigApp** (`apps/config.py`): Toggle added to Summaries tab
5. **TemplateBuilderApp** (`apps/template_builder.py`): Apply saved theme on mount (standalone fix)

## Test Scope

- 958 tests pass (12 new: 7 modal widget, 4 show_builtins filtering, 4 notice integration)
- `lint-imports`: 4 contracts kept, 0 broken
- All pre-commit hooks pass (ruff, ruff-format, ty)

## Checks

- [x] Keep pull requests small so they can be easily reviewed