### PR TITLE
fix(l3): gate auto-amp by system-audio activity to stop voice doubling

### DIFF
--- a/src/lazy_take_notes/l3_interface_adapters/gateways/mixed_audio_source.py
+++ b/src/lazy_take_notes/l3_interface_adapters/gateways/mixed_audio_source.py
@@ -35,6 +35,13 @@ class MixedAudioSource:
     mic before mixing so speech clears the gate. Gain is computed from an exponential
     moving average of mic RMS and capped at max_mic_gain (default 10x). The peak
     limiter prevents the amplified signal from clipping.
+
+    Amp is gated by a second EMA of system-audio RMS: when system audio is currently
+    playing (sys RMS above noise floor) the gain is held at 1x. Without this gate,
+    speaker-to-mic acoustic bleed gets boosted alongside genuine speech, and the
+    remote voice appears in the mix twice — once via the system tap, once via the
+    amplified mic copy — producing a doubled / phased output that degrades both
+    recording quality and transcription accuracy.
     """
 
     def __init__(
@@ -65,6 +72,7 @@ class MixedAudioSource:
         self._noise_floor = 0.003
         self._max_mic_gain = max_mic_gain
         self._mic_rms_ema: float = 0.0
+        self._sys_rms_ema: float = 0.0
         self._mic_gain: float = 1.0
         self._gain_logged: bool = False
 
@@ -120,9 +128,16 @@ class MixedAudioSource:
             else:
                 self._mic_rms_ema += 0.05 * (self.last_mic_rms - self._mic_rms_ema)
 
-        # Auto-amplify: when EMA indicates "speaking but below VAD gate", boost
-        # mic so speech clears silence_threshold. Peak limiter catches overflow.
-        if self._mic_rms_ema > self._noise_floor and self._mic_rms_ema < self._target_mic_rms:
+        # Auto-amplify: when EMA indicates "speaking but below VAD gate" AND the
+        # system audio EMA shows the loopback is silent, boost mic so speech clears
+        # silence_threshold. The sys-quiet gate prevents amplifying acoustic bleed
+        # (speaker → mic) when the user is on speakers — without it, the remote
+        # voice gets doubled in the mix. Peak limiter catches overflow.
+        if (
+            self._mic_rms_ema > self._noise_floor
+            and self._mic_rms_ema < self._target_mic_rms
+            and self._sys_rms_ema <= self._noise_floor
+        ):
             self._mic_gain = min(self._target_mic_rms / self._mic_rms_ema, self._max_mic_gain)
             if not self._gain_logged:
                 log.info(
@@ -166,6 +181,14 @@ class MixedAudioSource:
             sys = np.pad(self._sys_buf, (0, n - len(self._sys_buf)))
             self._sys_buf = np.array([], dtype=np.float32)
 
+        # Track system audio activity for next read's amp gate (one-chunk lag is
+        # well below the EMA time constant). Same alpha as mic EMA for symmetry.
+        sys_rms = math.sqrt(float(np.dot(sys, sys)) / sys.size) if sys.size else 0.0
+        if self._sys_rms_ema == 0.0:
+            self._sys_rms_ema = sys_rms
+        else:
+            self._sys_rms_ema += 0.05 * (sys_rms - self._sys_rms_ema)
+
         # Peak limiter: scale to 0.99 only when clipping. Two scalar reductions
         # (max + min) instead of np.abs() to avoid a temp-array allocation on
         # every read (~31 Hz hot path).
@@ -190,6 +213,7 @@ class MixedAudioSource:
         self._sys_buf = np.array([], dtype=np.float32)
         self.last_mic_rms = 0.0
         self._mic_rms_ema = 0.0
+        self._sys_rms_ema = 0.0
         self._mic_gain = 1.0
         self._gain_logged = False
         self._mic.drain()

--- a/tests/l3_interface_adapters/gateways/test_mixed_audio_source.py
+++ b/tests/l3_interface_adapters/gateways/test_mixed_audio_source.py
@@ -298,6 +298,34 @@ class TestMixedAudioSource:
         assert result_rms < 0.018, f'Expected capped RMS < 0.018, got {result_rms}'
         assert result_rms > 0.012, f'Expected amplified RMS > 0.012, got {result_rms}'
 
+    def test_no_amplify_when_system_audio_is_active(self):
+        """When system audio is playing, mic must NOT be auto-amplified — otherwise
+        speaker-to-mic acoustic bleed gets boosted and the remote voice ends up in
+        the mix twice (once via the loopback tap, once via the amplified mic copy).
+        That doubling/phasing was the original 'voice tracks mix together' bug."""
+        mic = FakeAudioSource()
+        sys_audio = FakeAudioSource()
+        src = MixedAudioSource(mic, sys_audio, silence_threshold=0.01)
+        src.open(16000, 1)
+
+        # mic carries quiet acoustic bleed (in the [noise_floor, target] band that
+        # would normally trigger amp), sys carries the actual playing voice.
+        bleed = np.full(100, 0.005, dtype=np.float32)
+        sys_active = np.full(100, 0.05, dtype=np.float32)
+
+        for _ in range(20):  # let both EMAs converge
+            src._mic_q.put(bleed.copy())  # noqa: SLF001
+            src._sys_q.put(sys_active.copy())  # noqa: SLF001
+            src.read(timeout=0.5)
+
+        src._mic_q.put(bleed.copy())  # noqa: SLF001
+        src._sys_q.put(sys_active.copy())  # noqa: SLF001
+        src.read(timeout=0.5)
+        src.close()
+
+        # Without the sys-active gate the gain would be ~5x. The gate must hold it at 1x.
+        assert src._mic_gain == 1.0, f'Expected gain held at 1.0x, got {src._mic_gain}x'  # noqa: SLF001
+
     def test_drain_clears_queues_and_source_buffers(self):
         """drain() must empty our queues AND delegate to the underlying sources."""
         mic = FakeAudioSource(chunks=[np.array([0.1, 0.2], dtype=np.float32)])


### PR DESCRIPTION
## Reason

On speakers, the mic picks up the loopback voice at low amplitude and the auto-amp (commit 38d5f18) boosts it 3-7x, putting the same voice into the mix twice with a time offset — audible doubling, degraded Whisper output.

## Changes

1. **MixedAudioSource** (`src/lazy_take_notes/l3_interface_adapters/gateways/mixed_audio_source.py`): track a second EMA over the consumed sys slice; gate auto-amp on `sys_rms_ema <= noise_floor` so gain stays at 1x whenever loopback audio is active. Reset state in `drain()`. Bluetooth/far-mic case still amplifies when sys is genuinely silent.
2. **Regression test** (`tests/l3_interface_adapters/gateways/test_mixed_audio_source.py`): `test_no_amplify_when_system_audio_is_active` asserts gain holds at 1.0x with quiet mic + active sys.

## Test Scope

- 18/18 mixed_audio_source tests pass, including the new regression. Full suite: 959/959 green.
- `lint-imports`: 4 contracts kept, 0 broken.
- Offline reproducer (continuous tone, 10% bleed, 60ms acoustic delay):
  - Before: gain 3.52x / 6.91x, mixed RMS +23% / +51% above sys-only.
  - After:  gain 1.00x in all scenarios, mixed RMS within physical-bleed bound (+5.7% / +5.6%).
- No echo cancellation added — unavoidable physical bleed (~10%) remains; only the amplification is removed.

## Checks

- [x] Keep pull requests small so they can be easily reviewed