### PR TITLE
perf(l2): pre-allocate transcribe buffer to fix consumer-loop lag

### DIFF
--- a/src/lazy_take_notes/l2_use_cases/transcribe_audio_use_case.py
+++ b/src/lazy_take_notes/l2_use_cases/transcribe_audio_use_case.py
@@ -37,7 +37,15 @@ class TranscribeAudioUseCase:
         self._min_speech_samples = int(SAMPLE_RATE * 2.0)
         self._silence_threshold = silence_threshold
 
-        self._buffer = np.array([], dtype=np.float32)
+        # Audio buffer is stored in a pre-allocated array that grows exponentially
+        # on demand. The valid prefix is `_storage[:_buffer_size]`; reads go through
+        # the `_buffer` view. This makes feed_audio amortised O(1) in the chunk
+        # size instead of O(buffer_size) — the previous np.concatenate-per-feed
+        # turned long meetings under whisper backpressure into a quadratic CPU
+        # sink that saturated the audio_worker consumer loop and caused live
+        # level-meter lag.
+        self._storage = np.zeros(SAMPLE_RATE * 10, dtype=np.float32)
+        self._buffer_size = 0
         self._is_first_chunk = True
         self._session_offset: float = 0.0  # wall-clock offset of buffer start
 
@@ -45,17 +53,55 @@ class TranscribeAudioUseCase:
     def overlap(self) -> float:
         return self._overlap_samples / SAMPLE_RATE
 
+    @property
+    def _buffer(self) -> np.ndarray:
+        """View of the current valid audio samples — read-only conceptually.
+
+        Callers that previously did `self._buffer = X` must instead use
+        `_replace_buffer(X)` so the underlying storage stays in sync.
+        """
+        return self._storage[: self._buffer_size]
+
+    def _replace_buffer(self, value: np.ndarray) -> None:
+        """Reset buffer contents to `value`. Handles overlap-safe self-copies."""
+        n = len(value)
+        if n == 0:
+            self._buffer_size = 0
+            return
+        if n > len(self._storage):
+            new_cap = max(n, len(self._storage) * 2)
+            self._storage = np.zeros(new_cap, dtype=np.float32)
+            self._storage[:n] = value
+        else:
+            # `value` may be a view into self._storage (e.g. self._buffer[-overlap:]).
+            # Slice-assigning across overlapping regions on the same array is undefined,
+            # so take a copy when the source aliases our storage.
+            src = value.copy() if value.base is self._storage else value
+            self._storage[:n] = src
+        self._buffer_size = n
+
     def set_session_offset(self, offset: float) -> None:
         """Set the current wall-clock offset in seconds from session start."""
         self._session_offset = offset
 
     def feed_audio(self, data: np.ndarray) -> None:
-        """Append raw audio samples to the internal buffer."""
-        self._buffer = np.concatenate([self._buffer, data.flatten()])
+        """Append raw audio samples to the internal buffer (amortised O(1))."""
+        flat = data.flatten() if data.ndim > 1 else data
+        n = len(flat)
+        if n == 0:
+            return
+        needed = self._buffer_size + n
+        if needed > len(self._storage):
+            new_cap = max(needed, len(self._storage) * 2)
+            new_storage = np.zeros(new_cap, dtype=np.float32)
+            new_storage[: self._buffer_size] = self._storage[: self._buffer_size]
+            self._storage = new_storage
+        self._storage[self._buffer_size : needed] = flat
+        self._buffer_size = needed
 
     def reset_buffer(self) -> None:
         """Discard accumulated audio (e.g. after pause)."""
-        self._buffer = np.array([], dtype=np.float32)
+        self._buffer_size = 0
 
     def should_trigger(self) -> bool:
         """Check if the buffer should be processed."""
@@ -87,7 +133,7 @@ class TranscribeAudioUseCase:
 
         rms = np.sqrt(np.mean(buf**2))
         if rms < self._silence_threshold:
-            self._buffer = (
+            self._replace_buffer(
                 buf[-self._overlap_samples :] if self._overlap_samples > 0 else np.array([], dtype=np.float32)
             )
             return None
@@ -97,7 +143,9 @@ class TranscribeAudioUseCase:
         current_hints = list(self._current_hints)
         is_first = self._is_first_chunk
 
-        self._buffer = buf[-self._overlap_samples :] if self._overlap_samples > 0 else np.array([], dtype=np.float32)
+        self._replace_buffer(
+            buf[-self._overlap_samples :] if self._overlap_samples > 0 else np.array([], dtype=np.float32)
+        )
         self._is_first_chunk = False
 
         return snapshot, current_hints, buffer_wall_start, is_first
@@ -144,7 +192,7 @@ class TranscribeAudioUseCase:
         # Skip if entire buffer is silence
         rms = np.sqrt(np.mean(buf**2))
         if rms < self._silence_threshold:
-            self._buffer = (
+            self._replace_buffer(
                 buf[-self._overlap_samples :] if self._overlap_samples > 0 else np.array([], dtype=np.float32)
             )
             return []
@@ -182,9 +230,9 @@ class TranscribeAudioUseCase:
 
         # Retain overlap tail
         if self._overlap_samples > 0:
-            self._buffer = buf[-self._overlap_samples :]
+            self._replace_buffer(buf[-self._overlap_samples :])
         else:
-            self._buffer = np.array([], dtype=np.float32)
+            self._replace_buffer(np.array([], dtype=np.float32))
 
         return new_segments
 

--- a/tests/l2_use_cases/test_transcribe_audio.py
+++ b/tests/l2_use_cases/test_transcribe_audio.py
@@ -78,6 +78,50 @@ class TestTranscribeAudioUseCase:
         # Transcriber should NOT have been called
         assert len(fake.transcribe_calls) == 0
 
+    def test_feed_audio_grows_storage_beyond_initial_capacity(self):
+        """Internal storage starts at 10s and must grow on demand without losing
+        samples. Regression guard for the pre-allocated buffer that replaced
+        np.concatenate-per-feed (which was O(n) per call and caused live level
+        meter lag under whisper backpressure on long meetings)."""
+        fake = FakeTranscriber()
+        uc = TranscribeAudioUseCase(transcriber=fake, language='en', chunk_duration=1000.0)
+
+        # Feed 25 seconds in 32-ms chunks — exceeds the 10s pre-allocation,
+        # triggering at least one storage grow.
+        chunk = np.full(512, 0.05, dtype=np.float32)
+        n_chunks = 25 * SAMPLE_RATE // 512
+        for _ in range(n_chunks):
+            uc.feed_audio(chunk)
+
+        assert len(uc._buffer) == n_chunks * 512  # noqa: SLF001
+        # All samples preserved at the expected value.
+        np.testing.assert_allclose(uc._buffer, 0.05, atol=1e-6)  # noqa: SLF001
+
+    def test_feed_audio_after_reset_to_tail_continues_correctly(self):
+        """After prepare_buffer resets the buffer to the overlap tail, the next
+        feed_audio must extend that tail correctly — exercises the _replace_buffer
+        path that takes a copy when the new contents alias internal storage."""
+        fake = FakeTranscriber(segments=[TranscriptSegment(text='x', wall_start=0, wall_end=1)])
+        uc = TranscribeAudioUseCase(transcriber=fake, language='en', chunk_duration=2.0, overlap=0.5)
+
+        # Feed 2 seconds at amplitude 0.5 so the buffer triggers and prepare_buffer
+        # returns a non-silent snapshot.
+        loud = np.full(SAMPLE_RATE * 2, 0.5, dtype=np.float32)
+        uc.feed_audio(loud)
+        prepared = uc.prepare_buffer()
+        assert prepared is not None
+
+        # Buffer is now reset to the last 0.5s = 8000 samples of value 0.5.
+        assert len(uc._buffer) == int(SAMPLE_RATE * 0.5)  # noqa: SLF001
+        np.testing.assert_allclose(uc._buffer, 0.5, atol=1e-6)  # noqa: SLF001
+
+        # Feed a fresh chunk; the tail must remain intact and the new samples appended.
+        fresh = np.full(SAMPLE_RATE, 0.7, dtype=np.float32)
+        uc.feed_audio(fresh)
+        assert len(uc._buffer) == int(SAMPLE_RATE * 0.5) + SAMPLE_RATE  # noqa: SLF001
+        np.testing.assert_allclose(uc._buffer[: int(SAMPLE_RATE * 0.5)], 0.5, atol=1e-6)  # noqa: SLF001
+        np.testing.assert_allclose(uc._buffer[int(SAMPLE_RATE * 0.5) :], 0.7, atol=1e-6)  # noqa: SLF001
+
     def test_reset_buffer(self):
         fake = FakeTranscriber()
         uc = TranscribeAudioUseCase(transcriber=fake, language='zh', chunk_duration=1.0)


### PR DESCRIPTION
## Reason

`feed_audio()` did `self._buffer = np.concatenate([self._buffer, data])` on every audio chunk — O(buffer_size) per call. Under whisper backpressure the audio_worker skips submitting new transcriptions while the previous is in flight, so the buffer grows unbounded. Over a long meeting the cumulative cost is quadratic in chunk count and the consumer loop falls behind real time. Symptom: live level meter keeps moving after the meeting ended, transcript hasn't caught up.

## Changes

1. **TranscribeAudioUseCase** (`src/lazy_take_notes/l2_use_cases/transcribe_audio_use_case.py`): internal buffer is now a pre-allocated `np.ndarray` with a separate `_buffer_size` cursor. `feed_audio()` slice-assigns into the existing storage and grows capacity exponentially — amortised O(1) in the chunk size. `self._buffer` is exposed as a read-only view via a property so RMS / indexing / len call sites are unchanged. Six reset-to-tail assignments go through `_replace_buffer()` which takes a defensive copy when the new value aliases internal storage (avoids numpy slice-assign UB on overlapping ranges).
2. **Regression tests** (`tests/l2_use_cases/test_transcribe_audio.py`): two new tests — storage exceeding the initial 10s pre-allocation, and feed-after-reset-to-tail where the tail is a view into the storage being overwritten.

## Test Scope

- 959/959 tests pass; +2 new regression tests for the growth path and the aliased-reset path.
- `lint-imports`: 4 contracts kept, 0 broken.
- Offline microbenchmark (300s of audio, never draining = worst-case backlog):
  - Before: per-call cost 0.005 → 0.443 ms (94x growth); cumulative 4.32 s wall time burned in feed_audio alone.
  - After: bounded at ~1 µs across the whole range; cumulative 0.01 s.

## Checks

- [x] Keep pull requests small so they can be easily reviewed