### PR TITLE
perf(l3): linearise MixedAudioSource sys_buf catch-up drain

### DIFF
--- a/src/lazy_take_notes/l3_interface_adapters/gateways/mixed_audio_source.py
+++ b/src/lazy_take_notes/l3_interface_adapters/gateways/mixed_audio_source.py
@@ -161,11 +161,18 @@ class MixedAudioSource:
         # Drain ALL available system chunks into the rolling buffer non-blocking.
         # get_nowait() is intentional: blocking here would stall the mic path and
         # cause _mic_q to accumulate unboundedly.
+        # Collect into a list first and concatenate once — the prior pattern of
+        # re-concatenating onto _sys_buf inside the loop was O(K²) in the number
+        # of queued chunks, which produced multi-second stalls on a single read()
+        # when the consumer had fallen behind by minutes (3000 chunks → ~2.6 s).
+        pending: list[np.ndarray] = []
         while True:
             try:
-                self._sys_buf = np.concatenate([self._sys_buf, self._sys_q.get_nowait()])
+                pending.append(self._sys_q.get_nowait())
             except queue.Empty:
                 break
+        if pending:
+            self._sys_buf = np.concatenate([self._sys_buf, *pending]) if self._sys_buf.size else np.concatenate(pending)
 
         if len(self._sys_buf) == 0:
             return mic  # no system audio yet; pass mic through at full amplitude

--- a/tests/l3_interface_adapters/gateways/test_mixed_audio_source.py
+++ b/tests/l3_interface_adapters/gateways/test_mixed_audio_source.py
@@ -326,6 +326,49 @@ class TestMixedAudioSource:
         # Without the sys-active gate the gain would be ~5x. The gate must hold it at 1x.
         assert src._mic_gain == 1.0, f'Expected gain held at 1.0x, got {src._mic_gain}x'  # noqa: SLF001
 
+    def test_sys_queue_backlog_drained_into_one_concat(self):
+        """When the consumer has fallen behind by many sys chunks, the catch-up
+        drain inside read() must complete in linear time. The prior implementation
+        re-concatenated onto _sys_buf inside the per-chunk loop (O(K²) memcpy),
+        which stalled a single read() for seconds when K reached the thousands —
+        directly causing the user-reported long-meeting lag spiral.
+
+        We can't easily assert on wall time here (CI noise), but we can pin the
+        observable semantics: every queued sys chunk's samples end up in _sys_buf
+        (or get consumed into the mixed output) regardless of how many were queued.
+        Concat ordering matters: the first-queued chunk's samples should land
+        before later ones."""
+        mic = FakeAudioSource()
+        sys_audio = FakeAudioSource()
+        src = MixedAudioSource(mic, sys_audio)
+        src.open(16000, 1)
+
+        # Pre-load 200 sys chunks (each tagged with a sentinel value so order is checkable).
+        sys_chunk_n = 100
+        n_chunks = 200
+        for i in range(n_chunks):
+            tag = (i + 1) / 1000.0  # 0.001, 0.002, ... distinct per chunk
+            src._sys_q.put(np.full(sys_chunk_n, tag, dtype=np.float32))  # noqa: SLF001
+
+        # Mic chunk small enough that one read consumes only the first sys chunk's samples,
+        # leaving the rest in _sys_buf where we can inspect ordering.
+        src._mic_q.put(np.zeros(10, dtype=np.float32))  # noqa: SLF001
+        result = src.read(timeout=0.5)
+        assert result is not None
+
+        # After the read, _sys_buf should hold the remaining (n_chunks * sys_chunk_n) - 10 samples
+        # with the original chunk ordering preserved.
+        remaining = src._sys_buf  # noqa: SLF001
+        expected_total = n_chunks * sys_chunk_n - 10
+        assert len(remaining) == expected_total, f'Expected {expected_total} samples remaining, got {len(remaining)}'
+        # The first chunk had tag 0.001; the consumed 10 samples came from it. The
+        # next sys_chunk_n - 10 samples should still be tag 0.001, then chunk 2 starts.
+        np.testing.assert_allclose(remaining[: sys_chunk_n - 10], 0.001, atol=1e-6)
+        np.testing.assert_allclose(remaining[sys_chunk_n - 10 : 2 * sys_chunk_n - 10], 0.002, atol=1e-6)
+        # Spot-check the last chunk landed at the end.
+        np.testing.assert_allclose(remaining[-sys_chunk_n:], n_chunks / 1000.0, atol=1e-6)
+        src.close()
+
     def test_drain_clears_queues_and_source_buffers(self):
         """drain() must empty our queues AND delegate to the underlying sources."""
         mic = FakeAudioSource(chunks=[np.array([0.1, 0.2], dtype=np.float32)])


### PR DESCRIPTION
## Reason

The catch-up drain in `MixedAudioSource.read()` did `self._sys_buf = np.concatenate([self._sys_buf, get_nowait()])` per queued chunk — O(K²) memcpy in the number of queued chunks. For a small backlog (K=10) this is invisible. Once the consumer fell behind by minutes — say after a digest stall or whisper backpressure on a long meeting — K reached the thousands and a single `read()` stalled for seconds, which queued more producer data and turned a transient slowdown into a permanent lag spiral. This is the tertiary lag mechanism flagged when PR #34 landed.

## Changes

1. **MixedAudioSource** (`src/lazy_take_notes/l3_interface_adapters/gateways/mixed_audio_source.py`): collect every queued chunk into a list first, then call `np.concatenate` once with the previous `_sys_buf` prepended. Single allocation instead of K growing allocations. Same observable behaviour — samples land in `_sys_buf` in their original order.
2. **Regression test** (`tests/l3_interface_adapters/gateways/test_mixed_audio_source.py`): `test_sys_queue_backlog_drained_into_one_concat` queues 200 sys chunks tagged with distinct sentinel values, runs one read consuming 10 samples, and asserts the remaining ~20 000 samples retain the original chunk ordering.

## Test Scope

- 19/19 mixed_audio_source tests pass (+1 new regression); full suite 962/962 green.
- `lint-imports`: 4 contracts kept, 0 broken.
- Offline microbenchmark, single `read()` after pre-loading sys_q with K chunks:

| K (chunks) | Backlog | Before | After | Speedup |
|---:|---:|---:|---:|---:|
| 10 | 1.0 s | 0.10 ms | 0.06 ms | ~1.7x |
| 100 | 10.0 s | 1.35 ms | 0.15 ms | ~9x |
| 500 | 50.0 s | 45.73 ms | 0.76 ms | ~60x |
| 1000 | 100.0 s | 222.95 ms | 1.37 ms | ~163x |
| 2000 | 200.0 s | 1137.13 ms | 3.03 ms | ~375x |
| 3000 | 300.0 s | 2607.94 ms | 4.70 ms | **~555x** |

## Checks

- [x] Keep pull requests small so they can be easily reviewed