### PR TITLE
fix(l4): wave meter renders silent below the configured silence_threshold

### DIFF
--- a/src/lazy_take_notes/l4_frameworks_and_drivers/apps/record.py
+++ b/src/lazy_take_notes/l4_frameworks_and_drivers/apps/record.py
@@ -83,7 +83,9 @@ class RecordApp(BaseApp):
 
     def on_mount(self) -> None:
         super().on_mount()
-        self.query_one('#status-bar', StatusBar).mode_label = 'Record'
+        bar = self.query_one('#status-bar', StatusBar)
+        bar.mode_label = 'Record'
+        bar.silence_threshold = self._config.transcription.silence_threshold
         self._start_audio_worker()
         if not CONSENT_NOTICED_PATH.exists():
             self.push_screen(ConsentNotice(on_suppress=self._suppress_consent_notice))

--- a/src/lazy_take_notes/l4_frameworks_and_drivers/apps/transcribe.py
+++ b/src/lazy_take_notes/l4_frameworks_and_drivers/apps/transcribe.py
@@ -77,7 +77,9 @@ class TranscribeApp(BaseApp):
 
     def on_mount(self) -> None:
         super().on_mount()
-        self.query_one('#status-bar', StatusBar).mode_label = 'Transcribe'
+        bar = self.query_one('#status-bar', StatusBar)
+        bar.mode_label = 'Transcribe'
+        bar.silence_threshold = self._config.transcription.silence_threshold
         self._start_file_worker()
 
     def _start_file_worker(self) -> None:  # pragma: no cover -- thin thread launcher; patched out in tests

--- a/src/lazy_take_notes/l4_frameworks_and_drivers/widgets/status_bar.py
+++ b/src/lazy_take_notes/l4_frameworks_and_drivers/widgets/status_bar.py
@@ -18,8 +18,12 @@ _DB_FLOOR = -60.0
 _DB_RANGE = 49.0  # -60 to -11
 
 
-def _rms_to_char(rms: float) -> str:
-    if math.isnan(rms) or rms < 1e-7:
+def _rms_to_char(rms: float, silence_threshold: float = 0.0) -> str:
+    # Treat anything the VAD considers silent as visually silent too. Without this,
+    # quiet mic ambient (~0.003 RMS = -50 dB) sat above the -60 dB floor and the
+    # wave kept showing visible bars after the meeting ended — looked like "lag"
+    # to the user even though the pipeline had already reported silent audio.
+    if math.isnan(rms) or rms < max(silence_threshold, 1e-7):
         return _WAVE_CHARS[0]
     if math.isinf(rms):
         return _WAVE_CHARS[7]
@@ -53,6 +57,11 @@ class StatusBar(Static):
     buf_count: reactive[int] = reactive(0)
     buf_max: reactive[int] = reactive(15)
     audio_level: reactive[float] = reactive(0.0)
+    # Below this RMS, render the wave as fully silent (▁). Apps set this from
+    # the user's configured silence_threshold so the meter and the VAD agree on
+    # what counts as silent. Default 0 keeps backward compat for tests that
+    # construct StatusBar without configuring it.
+    silence_threshold: reactive[float] = reactive(0.0)
     last_digest_time: reactive[float] = reactive(0.0)
     mic_muted: reactive[bool] = reactive(False)
     mode_label: reactive[str] = reactive('')
@@ -157,7 +166,7 @@ class StatusBar(Static):
             else:
                 left_parts.append(f'last {int(since / 60)}m ago')
         if self.recording:
-            wave = ''.join(_rms_to_char(v) for v in self._level_history)
+            wave = ''.join(_rms_to_char(v, self.silence_threshold) for v in self._level_history)
             left_parts.append(wave)
         if self.transcribing:
             left_parts.append('⟳ Transcribing\u2026')

--- a/tests/l4_frameworks_and_drivers/widgets/test_status_bar.py
+++ b/tests/l4_frameworks_and_drivers/widgets/test_status_bar.py
@@ -47,6 +47,21 @@ class TestRmsToChar:
         assert indices == sorted(indices)
         assert indices[-1] > indices[0]
 
+    def test_silence_threshold_renders_as_lowest_bar(self):
+        """RMS at or below silence_threshold should render as ▁ — aligns the wave
+        with the VAD's notion of silent. Without this, quiet mic ambient (e.g.
+        0.003 RMS) sat above the -60 dB floor and kept the wave visibly active
+        long after the system audio actually stopped, looking like consumer-loop
+        lag when it was actually the meter being more sensitive than the VAD."""
+        # Without the threshold passed, 0.003 RMS (≈ -50 dB) maps to ▂ via the
+        # dB floor at -60 dB. That's exactly the symptom this fix addresses.
+        assert _rms_to_char(0.003) == '▂'
+        # With silence_threshold matching the VAD's, 0.003 renders as ▁.
+        assert _rms_to_char(0.003, silence_threshold=0.01) == '▁'
+        assert _rms_to_char(0.0099, silence_threshold=0.01) == '▁'
+        # Above the threshold, the dB scale takes over as before.
+        assert _rms_to_char(0.05, silence_threshold=0.01) != '▁'
+
 
 def _make_app(tmp_path):
     from lazy_take_notes.l3_interface_adapters.controllers.session_controller import SessionController


### PR DESCRIPTION
## Reason

After the previous lag PRs landed, the user reported "still ~2 s of lag" before the wave goes fully silent. Investigation showed the audio pipeline drops to mic-ambient levels (~0.003 RMS) within 185 ms — fast. The visual lag is the wave's dB floor: it was at -60 dB (~0.001 RMS), so quiet ambient at -50 dB rendered as ▂ forever. The VAD considered that signal silent (below the configured 0.01 silence_threshold), but the meter disagreed — looked like consumer-loop lag when it was actually the meter being more sensitive than the system it was visualising.

## Changes

1. **StatusBar** (`src/lazy_take_notes/l4_frameworks_and_drivers/widgets/status_bar.py`): reactive `silence_threshold` attribute (default 0 for backward compat). `_rms_to_char` returns ▁ when RMS falls at or below the threshold; the dB scale still drives visible bars above it.
2. **RecordApp / TranscribeApp** (`src/lazy_take_notes/l4_frameworks_and_drivers/apps/{record,transcribe}.py`): pass `config.transcription.silence_threshold` to the StatusBar in `on_mount` so the meter and the VAD always agree.
3. **Tests** (`tests/l4_frameworks_and_drivers/widgets/test_status_bar.py`): `test_silence_threshold_renders_as_lowest_bar` pins the new behaviour — `_rms_to_char(0.003)` still maps to ▂ at the default settings (documenting the original symptom), but `_rms_to_char(0.003, silence_threshold=0.01)` maps to ▁ as intended.

## Test Scope

- 14/14 status_bar tests pass (+1 new). Full suite: 963/963 green.
- `lint-imports`: 4 contracts kept, 0 broken.
- Offline reproducer: with sys switching to silent while mic emits ambient 0.003 RMS, the AudioLevel drops to 0.003 within 185 ms. Pre-fix the wave shows ▂▂▂▂▂▂ indefinitely; post-fix it shows ▁▁▁▁▁▁ within ~600 ms (one level-history window).

## Checks

- [x] Keep pull requests small so they can be easily reviewed