### PR TITLE
perf(l4): decouple audio-level meter updates from Textual message queue

### DIFF
--- a/src/lazy_take_notes/l4_frameworks_and_drivers/apps/record.py
+++ b/src/lazy_take_notes/l4_frameworks_and_drivers/apps/record.py
@@ -57,6 +57,11 @@ class RecordApp(BaseApp):
         self._audio_shutdown = threading.Event()
         self._audio_stopped = False
         self._pending_quit = False
+        # Latest audio RMS — written from the worker thread, read by a timer on
+        # the UI loop. Float assignment is atomic under the GIL; no lock needed.
+        # Using a slot instead of AudioLevel messages keeps the meter responsive
+        # under load: producer writes overwrite each other rather than queueing.
+        self._latest_audio_level: float = 0.0
 
     def _hints_for_state(self, state: str) -> str:
         if state == 'recording':
@@ -86,6 +91,8 @@ class RecordApp(BaseApp):
         bar = self.query_one('#status-bar', StatusBar)
         bar.mode_label = 'Record'
         bar.silence_threshold = self._config.transcription.silence_threshold
+        # Poll the worker's latest-RMS slot at the meter's display cadence.
+        self.set_interval(0.1, self._poll_audio_level)
         self._start_audio_worker()
         if not CONSENT_NOTICED_PATH.exists():
             self.push_screen(ConsentNotice(on_suppress=self._suppress_consent_notice))
@@ -149,7 +156,23 @@ class RecordApp(BaseApp):
             save_audio=self._config.output.save_audio,
             transcriber=self._transcriber,
             audio_source=self._audio_source,
+            level_setter=self._set_latest_audio_level,
         )
+
+    def _set_latest_audio_level(self, rms: float) -> None:
+        """Worker-thread entry point — writes the latest RMS to a slot polled
+        by the UI timer. Float assignment is atomic under the GIL."""
+        self._latest_audio_level = rms
+
+    def _poll_audio_level(self) -> None:
+        """UI-thread timer — copies the latest RMS into the StatusBar reactive.
+        Decouples the producer's 10 Hz post rate from the UI render rate so the
+        wave can't fall behind real time when the loop is under load."""
+        try:
+            bar = self.query_one('#status-bar', StatusBar)
+            bar.audio_level = self._latest_audio_level
+        except Exception:  # noqa: S110, BLE001 -- TUI race guard; widget may not exist during teardown
+            pass
 
     def _cancel_audio_workers(self) -> None:
         self._audio_shutdown.set()

--- a/src/lazy_take_notes/l4_frameworks_and_drivers/workers/audio_worker.py
+++ b/src/lazy_take_notes/l4_frameworks_and_drivers/workers/audio_worker.py
@@ -77,10 +77,20 @@ def run_audio_worker(
     save_audio: bool = False,
     transcriber=None,
     audio_source: AudioSource | None = None,
+    level_setter=None,
 ) -> list[TranscriptSegment]:
     """Audio capture and transcription loop.
 
     Designed to run inside a Textual @work(thread=True) worker.
+
+    The optional `level_setter` callable lets callers bypass the post_message
+    queue for the high-rate AudioLevel update. The default writes an AudioLevel
+    message — fine for tests and short sessions. For long sessions, posting at
+    10 Hz can outpace the consumer (rendering / message-handler load) and
+    levels back up in Textual's queue, showing up as the wave lagging real
+    time. An app-provided level_setter that just stores the latest float in a
+    shared slot keeps the meter snappy under load: writes overwrite each other
+    rather than queueing, and the consumer polls the latest value.
     """
     # Load model
     post_message(AudioWorkerStatus(status='loading_model'))
@@ -302,7 +312,10 @@ def run_audio_worker(
                     if not np.isfinite(rms):
                         rms = 0.0
                     _level_accum.clear()
-                    post_message(AudioLevel(rms=rms))
+                    if level_setter is not None:
+                        level_setter(rms)
+                    else:
+                        post_message(AudioLevel(rms=rms))
                     _last_level_post = now_abs
 
                 # Periodic stats every 30s

--- a/tests/l4_frameworks_and_drivers/workers/test_audio_worker.py
+++ b/tests/l4_frameworks_and_drivers/workers/test_audio_worker.py
@@ -301,6 +301,42 @@ class TestAudioWorkerTranscription:
         # Return value includes segments
         assert len(result) >= 1
 
+    def test_level_setter_callback_bypasses_audio_level_message(self):
+        """When a level_setter is provided, the worker writes RMS to it and
+        skips posting AudioLevel messages. Lets RecordApp decouple the high-rate
+        level update from Textual's message queue so the wave can't fall behind
+        real time under render load."""
+        chunk = _make_nonsilent_chunk(1600)
+        fake_source = FakeAudioSource(chunks=[chunk, chunk, chunk])
+
+        messages: list = []
+        rms_writes: list[float] = []
+        call_count = 0
+
+        def is_cancelled():
+            nonlocal call_count
+            call_count += 1
+            return call_count > 5
+
+        run_audio_worker(
+            post_message=messages.append,
+            is_cancelled=is_cancelled,
+            model_path='test-model',
+            language='zh',
+            chunk_duration=0.1,
+            overlap=0.0,
+            silence_threshold=0.001,
+            transcriber=FakeTranscriber(),
+            audio_source=fake_source,
+            level_setter=rms_writes.append,
+        )
+
+        # level_setter received at least one RMS write
+        assert len(rms_writes) >= 1
+        assert rms_writes[0] > 0
+        # AudioLevel messages were NOT posted — the slot pattern replaced them
+        assert not [m for m in messages if isinstance(m, AudioLevel)]
+
     def test_transcription_posts_status_active_and_inactive(self):
         """TranscriptionStatus(active=True) posted before transcription, False after."""
         segments = [TranscriptSegment(text='hello', wall_start=0.0, wall_end=1.0)]


### PR DESCRIPTION
## Reason

The audio_worker posts AudioLevel messages at ~10 Hz throughout a session. Under load (heavy rendering, LLM digest task on the same loop, or any other CPU pressure on the UI thread) Textual's message processing can fall behind the post rate by a small constant fraction. Over a long recording the backlog accumulates linearly — a 3-minute meeting can leave the wave showing audio from many seconds ago, and the level meter keeps "moving" even after the source actually went silent (user reported ~9 s).

The minimal Pilot test does not reproduce this in isolation (a minimal app handles 300 messages over 30 s with zero drift), so the production trigger is something the minimal app does not exercise — full rendering load, competing async tasks, terminal I/O. Either way the pattern is fragile by design: a high-rate producer feeding a variable-rate consumer through a FIFO with no compaction.

## Changes

1. **audio_worker** (`src/lazy_take_notes/l4_frameworks_and_drivers/workers/audio_worker.py`): optional `level_setter` callable. When provided, the worker calls it with the latest RMS instead of posting `AudioLevel`. Default unchanged.
2. **RecordApp** (`src/lazy_take_notes/l4_frameworks_and_drivers/apps/record.py`): passes a setter that writes the float to `self._latest_audio_level` (atomic under the GIL) and registers a 100 ms `set_interval` timer that copies the slot into `StatusBar.audio_level`. If the UI loop is slow, writes overwrite each other rather than queueing, and the timer reads the latest value when it next fires.
3. **Test** (`tests/l4_frameworks_and_drivers/workers/test_audio_worker.py`): `test_level_setter_callback_bypasses_audio_level_message` pins the behaviour — when `level_setter` is provided, `AudioLevel` messages are not posted and the setter receives the RMS values directly.

TranscribeApp does not need this — `file_transcription_worker` doesn't post `AudioLevel`.

## Test Scope

- 962/962 tests pass (+1 new). `lint-imports`: 4 contracts kept, 0 broken.
- Pilot reproducer (`/tmp/repro_textual_backlog.py`) shows the *minimal* path handles 300 messages over 30 s with zero drift. Production behaviour may differ under render/CPU load; the slot pattern guarantees correctness either way.

## Related

This is the fourth fix in the long-meeting-lag investigation, after #33 (transcribe-buffer), #34 (swift-stdout-unbuffer), and #35 (sys_buf-drain). I cannot prove this is *the* remaining cause of the user's 9-second lag on a 3-minute input, but it removes the only remaining unbounded queue between the audio_worker and the wave widget.

## Checks

- [x] Keep pull requests small so they can be easily reviewed