### PR TITLE
chore(l4): add consumer drift + queue depth to audio_worker stats log

### DIFF
--- a/src/lazy_take_notes/l4_frameworks_and_drivers/workers/audio_worker.py
+++ b/src/lazy_take_notes/l4_frameworks_and_drivers/workers/audio_worker.py
@@ -311,14 +311,36 @@ def run_audio_worker(
                     rms_avg = _stats_rms_sum / _stats_rms_count if _stats_rms_count else 0.0
                     zero_pct = (_stats_zero_samples / _stats_total_samples * 100) if _stats_total_samples else 0.0
                     minutes, secs = divmod(int(elapsed), 60)
+                    # Consumer drift: samples the worker has consumed vs samples
+                    # that should have been produced if real-time were the only
+                    # constraint. Positive drift => the audio_worker is behind
+                    # real time (queues somewhere have backlog); zero drift =>
+                    # consumer keeping up and any perceived lag is downstream
+                    # of the worker (UI, rendering, terminal).
+                    expected_samples = int(elapsed * SAMPLE_RATE)
+                    drift_samples = expected_samples - total_samples_fed
+                    drift_s = drift_samples / SAMPLE_RATE
+                    # Queue sizes — only meaningful for MixedAudioSource; gracefully
+                    # ignore for any source that doesn't expose these.
+                    mic_q = getattr(audio_source, '_mic_q', None)
+                    sys_q = getattr(audio_source, '_sys_q', None)
+                    sys_buf = getattr(audio_source, '_sys_buf', None)
+                    qmic = mic_q.qsize() if mic_q is not None else -1
+                    qsys = sys_q.qsize() if sys_q is not None else -1
+                    qbuf = len(sys_buf) if sys_buf is not None else -1
                     log.info(
-                        'Audio stats [%d:%02d]: %d samples, rms=%.3f, zero=%.1f%%, transcriptions=%d',
+                        'Audio stats [%d:%02d]: %d samples, rms=%.3f, zero=%.1f%%, '
+                        'transcriptions=%d, drift=%+.2fs, mic_q=%d, sys_q=%d, sys_buf=%d',
                         minutes,
                         secs,
                         total_samples_fed,
                         rms_avg,
                         zero_pct,
                         _stats_transcriptions,
+                        drift_s,
+                        qmic,
+                        qsys,
+                        qbuf,
                     )
 
                     _stats_last_time = now_abs


### PR DESCRIPTION
## Reason

Honest: the four PRs (#33-#37) I have shipped for long-meeting lag each fix a plausible *contributor*, but I have not been able to prove which one (if any) is the actual root cause of "9 s of lag on a 3 min recording". Time to stop guessing and start measuring on the real environment.

## Changes

1. **audio_worker** (`src/lazy_take_notes/l4_frameworks_and_drivers/workers/audio_worker.py`): extend the every-30 s `Audio stats` log line with three new fields:
   - `drift`: elapsed wall time × `SAMPLE_RATE` vs `total_samples_fed`, in seconds. Positive drift means the audio_worker is consuming slower than real time — queues somewhere have backlog. Zero drift means the worker is keeping up and any perceived lag is downstream (UI, render, terminal).
   - `mic_q`, `sys_q`, `sys_buf`: queue depths inside `MixedAudioSource`. If these grow over time, the worker is the bottleneck. If they stay near zero while `drift` is positive, the bottleneck is producer-side (Swift binary, PortAudio, kernel pipe). If both are zero and the user still sees lag, the bottleneck is the UI layer.

## Test Scope

- 963/963 tests pass. `lint-imports`: 4 contracts kept, 0 broken.
- No behaviour change beyond an enhanced log line.

## How to read the output

The log appears at `~/Library/Application Support/lazy-take-notes/...` (or platformdirs equivalent). Look for `Audio stats` lines:

```
Audio stats [3:00]: 2880000 samples, rms=0.040, zero=0.0%, transcriptions=7, drift=+0.00s, mic_q=0, sys_q=0, sys_buf=512
```

- If at the end of a "laggy" session `drift` is large and positive (e.g. `+9.00s`), the consumer loop is genuinely behind real time and we need to find why the worker is slow.
- If `mic_q` or `sys_q` are climbing across stats lines, the consumer can't keep up with the producer threads.
- If `drift ≈ 0` and queues are empty but the user still observes lag, the bottleneck is in the UI layer (rendering / Textual message processing).

## Checks

- [x] Keep pull requests small so they can be easily reviewed