### PR TITLE
fix(l3): open sounddevice at native rate, decimate to 16 kHz in Python

### DIFF
--- a/src/lazy_take_notes/l3_interface_adapters/gateways/sounddevice_audio_source.py
+++ b/src/lazy_take_notes/l3_interface_adapters/gateways/sounddevice_audio_source.py
@@ -14,7 +14,19 @@ log = logging.getLogger('ltn.audio.sounddevice')
 
 
 class SounddeviceAudioSource:
-    """Wraps sounddevice.InputStream to provide audio chunks."""
+    """Wraps sounddevice.InputStream to provide audio chunks at SAMPLE_RATE.
+
+    Opens the device at its native rate and decimates to SAMPLE_RATE in Python
+    when the native rate is an integer multiple of the target. Relying on
+    PortAudio's internal resampling on macOS CoreAudio at common ratios (96 kHz
+    → 16 kHz) silently under-delivers samples by ~5 % — a 3-minute recording
+    consumes ~171 s of mic audio against 180 s of wall time, and the missing
+    mic samples leave the MixedAudioSource's sys_buf accumulating system audio
+    indefinitely (9 s of lag at 3 min, growing linearly with session length).
+
+    Falls back to PortAudio resampling when the native rate isn't a clean
+    integer multiple of SAMPLE_RATE (e.g. 44.1 kHz devices).
+    """
 
     def __init__(self) -> None:
         self._stream: sd.InputStream | None = None
@@ -23,21 +35,55 @@ class SounddeviceAudioSource:
 
     def open(self, sample_rate: int = SAMPLE_RATE, channels: int = 1) -> None:
         device_info = sd.query_devices(kind='input')
+        native_sr_raw = device_info.get('default_samplerate', float(sample_rate))
+        native_sr = int(round(native_sr_raw))
+
+        # Decimate in Python when native is an integer multiple of target rate
+        # (96 kHz → 16 kHz is ratio 6; 48 kHz → 16 kHz is ratio 3). Otherwise
+        # fall back to PortAudio's resampling and accept the drift.
+        if native_sr >= sample_rate and native_sr % sample_rate == 0 and native_sr != sample_rate:
+            stream_sr = native_sr
+            ratio = native_sr // sample_rate
+            # Lock the callback's frame count to a multiple of `ratio` so each
+            # callback decimates cleanly with no leftover samples. ~32 ms per
+            # callback at the target rate matches the previous default behaviour.
+            blocksize = ratio * 512
+        else:
+            stream_sr = sample_rate
+            ratio = 1
+            blocksize = 0  # let PortAudio pick
+
         log.info(
-            'opening sounddevice: device=%s, native_sr=%s, requested_sr=%d, channels=%d',
+            'opening sounddevice: device=%s, native_sr=%s, stream_sr=%d, decimation_ratio=%d, '
+            'blocksize=%d, channels=%d',
             device_info.get('name', '?'),
-            device_info.get('default_samplerate', '?'),
-            sample_rate,
+            native_sr_raw,
+            stream_sr,
+            ratio,
+            blocksize,
             channels,
         )
 
         def _callback(indata, frames, time_info, status):
             if status:
                 log.warning('PortAudio status: %s', status)
-            self._queue.put(indata.copy())
+            if ratio == 1:
+                self._queue.put(indata.copy())
+                return
+            # Box-filter decimate: average each consecutive `ratio`-sample group
+            # and emit one output sample. Voice content (≤ 4 kHz) sits well
+            # inside the boxcar's main lobe; high-frequency mic noise above the
+            # output Nyquist (8 kHz) is attenuated by the filter notches.
+            n_out = frames // ratio
+            if n_out == 0:
+                return
+            usable = indata[: n_out * ratio]
+            downsampled = usable.reshape(n_out, ratio, -1).mean(axis=1).astype(np.float32)
+            self._queue.put(downsampled.copy())
 
         self._stream = sd.InputStream(
-            samplerate=sample_rate,
+            samplerate=stream_sr,
+            blocksize=blocksize,
             channels=channels,
             dtype='float32',
             callback=_callback,

--- a/tests/l3_interface_adapters/gateways/test_sounddevice_audio_source.py
+++ b/tests/l3_interface_adapters/gateways/test_sounddevice_audio_source.py
@@ -9,7 +9,12 @@ import numpy as np
 MODULE = 'lazy_take_notes.l3_interface_adapters.gateways.sounddevice_audio_source'
 
 
-_FAKE_DEVICE_INFO = {'name': 'Test Input', 'default_samplerate': 48000.0}
+# Default fixture uses native rate = target rate, so ratio=1 (passthrough — no decimation).
+# Tests that exercise decimation supply a separate device info with a non-target native rate.
+_FAKE_DEVICE_INFO = {'name': 'Test Input', 'default_samplerate': 16000.0}
+_FAKE_DEVICE_INFO_48K = {'name': 'Test Input 48k', 'default_samplerate': 48000.0}
+_FAKE_DEVICE_INFO_96K = {'name': 'Test Input 96k', 'default_samplerate': 96000.0}
+_FAKE_DEVICE_INFO_44_1K = {'name': 'Test Input 44.1k', 'default_samplerate': 44100.0}
 
 
 class TestSounddeviceAudioSource:
@@ -31,6 +36,37 @@ class TestSounddeviceAudioSource:
         assert call_kwargs['dtype'] == 'float32'
         mock_stream.start.assert_called_once()
 
+    @patch(f'{MODULE}.sd.query_devices', return_value=_FAKE_DEVICE_INFO_96K)
+    @patch(f'{MODULE}.sd.InputStream')
+    def test_open_at_native_rate_for_integer_decimation(self, mock_stream_cls, _mock_qd):
+        """When native rate is an integer multiple of the target, open at native
+        and decimate in Python — bypasses PortAudio's resampling which silently
+        under-delivers samples on macOS CoreAudio at 96k → 16k."""
+        from lazy_take_notes.l3_interface_adapters.gateways.sounddevice_audio_source import SounddeviceAudioSource
+
+        mock_stream_cls.return_value = MagicMock()
+
+        SounddeviceAudioSource().open(16000, 1)
+
+        call_kwargs = mock_stream_cls.call_args.kwargs
+        # Stream opened at native rate, blocksize a multiple of the decimation ratio
+        assert call_kwargs['samplerate'] == 96000
+        assert call_kwargs['blocksize'] % 6 == 0
+
+    @patch(f'{MODULE}.sd.query_devices', return_value=_FAKE_DEVICE_INFO_44_1K)
+    @patch(f'{MODULE}.sd.InputStream')
+    def test_open_falls_back_to_target_rate_for_non_integer_ratio(self, mock_stream_cls, _mock_qd):
+        """Devices whose native rate isn't a clean multiple of the target (e.g.
+        44.1 kHz) fall back to PortAudio's resampling. Documented limitation."""
+        from lazy_take_notes.l3_interface_adapters.gateways.sounddevice_audio_source import SounddeviceAudioSource
+
+        mock_stream_cls.return_value = MagicMock()
+
+        SounddeviceAudioSource().open(16000, 1)
+
+        call_kwargs = mock_stream_cls.call_args.kwargs
+        assert call_kwargs['samplerate'] == 16000
+
     @patch(f'{MODULE}.sd.query_devices', return_value=_FAKE_DEVICE_INFO)
     @patch(f'{MODULE}.sd.InputStream')
     def test_callback_wires_to_queue(self, mock_stream_cls, _mock_qd):
@@ -44,7 +80,7 @@ class TestSounddeviceAudioSource:
 
         # Extract the callback from the InputStream constructor
         callback = mock_stream_cls.call_args.kwargs['callback']
-        # Simulate audio data arriving
+        # Simulate audio data arriving (passthrough path: ratio=1, no decimation)
         fake_data = np.array([[0.1], [0.2]], dtype=np.float32)
         callback(fake_data, 2, None, None)
 
@@ -52,6 +88,48 @@ class TestSounddeviceAudioSource:
         result = src.read(timeout=0.1)
         assert result is not None
         np.testing.assert_allclose(result, [0.1, 0.2], atol=1e-6)
+
+    @patch(f'{MODULE}.sd.query_devices', return_value=_FAKE_DEVICE_INFO_48K)
+    @patch(f'{MODULE}.sd.InputStream')
+    def test_callback_decimates_when_ratio_greater_than_one(self, mock_stream_cls, _mock_qd):
+        """48 kHz native → 16 kHz target → ratio 3. Each group of 3 input samples
+        averages into one output sample at the target rate."""
+        from lazy_take_notes.l3_interface_adapters.gateways.sounddevice_audio_source import SounddeviceAudioSource
+
+        mock_stream_cls.return_value = MagicMock()
+
+        src = SounddeviceAudioSource()
+        src.open(16000, 1)
+
+        callback = mock_stream_cls.call_args.kwargs['callback']
+        # 6 input frames @ 48k → 2 output frames @ 16k. Pairs averaged.
+        fake_data = np.array(
+            [[0.0], [0.3], [0.6], [0.9], [0.6], [0.3]],
+            dtype=np.float32,
+        )
+        callback(fake_data, 6, None, None)
+
+        result = src.read(timeout=0.1)
+        assert result is not None
+        # Groups: mean([0.0, 0.3, 0.6]) = 0.3 ; mean([0.9, 0.6, 0.3]) = 0.6
+        np.testing.assert_allclose(result, [0.3, 0.6], atol=1e-5)
+
+    @patch(f'{MODULE}.sd.query_devices', return_value=_FAKE_DEVICE_INFO_48K)
+    @patch(f'{MODULE}.sd.InputStream')
+    def test_callback_skips_when_frames_smaller_than_ratio(self, mock_stream_cls, _mock_qd):
+        """If a callback delivers fewer frames than the decimation ratio, drop
+        them — blocksize is configured to prevent this, but be defensive."""
+        from lazy_take_notes.l3_interface_adapters.gateways.sounddevice_audio_source import SounddeviceAudioSource
+
+        mock_stream_cls.return_value = MagicMock()
+
+        src = SounddeviceAudioSource()
+        src.open(16000, 1)
+
+        callback = mock_stream_cls.call_args.kwargs['callback']
+        callback(np.array([[0.1], [0.2]], dtype=np.float32), 2, None, None)
+
+        assert src.read(timeout=0.01) is None
 
     @patch(f'{MODULE}.sd.query_devices', return_value=_FAKE_DEVICE_INFO)
     @patch(f'{MODULE}.sd.InputStream')


### PR DESCRIPTION
## Reason

**Root cause finally identified, with direct evidence from a user session.** PR #38's diagnostic log showed:

| Time | drift | sys_buf samples | sys_buf seconds |
|---|---|---|---|
| 0:30 | +1.87 s | 29,846 | 1.87 s |
| 1:00 | +3.70 s | 59,244 | 3.70 s |
| 1:30 | +4.71 s | 75,360 | 4.71 s |
| 2:00 | +5.77 s | 92,259 | 5.77 s |
| 2:30 | +7.45 s | 118,960 | 7.43 s |
| 3:00 | +8.84 s | 141,079 | 8.82 s |

`drift` and `sys_buf` are nearly identical — the lag is the system-audio rolling buffer accumulating because mic produces samples slower than sys does. Math: `total_samples_fed = 2,738,934` over `180 s` = `15,216 sps` (4.9 % below the requested 16,000 sps). PortAudio reports no status warnings; the resample from the MacBook mic's 96 kHz native rate to 16 kHz just silently under-delivers samples.

Each `MixedAudioSource.read()` consumes `len(mic)` samples from `sys_buf`. With mic running slow, `sys_buf` grows linearly with session length and the mix carries system audio from N seconds ago. That's why the wave keeps showing activity long after the source went silent and why the lag scaled with input length (1m 15s → 2s, 3m → 9s).

## Changes

1. **SounddeviceAudioSource** (`src/lazy_take_notes/l3_interface_adapters/gateways/sounddevice_audio_source.py`): when the device's native rate is an integer multiple of the target (96 kHz → 6×, 48 kHz → 3×, 192 kHz → 12×), open the InputStream at the native rate and decimate to 16 kHz in Python. Lock `blocksize` to a multiple of the decimation ratio so each callback decimates cleanly. Decimation is a box-filter average over each `ratio`-sized group — voice content (≤ 4 kHz) sits well inside the boxcar's main lobe; the filter's notches attenuate high-frequency mic noise above the output Nyquist. Falls back to PortAudio's resampling for non-integer ratios (e.g. 44.1 kHz devices).
2. **Tests** (`tests/l3_interface_adapters/gateways/test_sounddevice_audio_source.py`): cover the integer-ratio open path (96 kHz), the non-integer fallback (44.1 kHz), the decimation math (48 kHz → 16 kHz with paired-averaging), and the existing passthrough at 16 kHz native.

## Test Scope

- 967/967 tests pass (+4 new). `lint-imports`: 4 contracts kept, 0 broken.
- Direct numerical evidence from the user's session log proves this is the real bottleneck. Other PRs (#33–#37) addressed plausible but secondary issues; this is the one that actually causes the linear-with-time lag.

## Caveats

- Box filter is a low-quality anti-alias filter. For voice transcription it's acceptable (voice band is well below the output Nyquist), but a proper polyphase FIR would be cleaner. Defer until quality complaints surface.
- Non-integer-ratio devices (44.1 kHz) still have the lag. A fractional resampler is out of scope here.

## Checks

- [x] Keep pull requests small so they can be easily reviewed