### PR TITLE
feat: headless recording mode + session CLI commands

### DIFF
--- a/src/lazy_take_notes/l1_entities/session_status.py
+++ b/src/lazy_take_notes/l1_entities/session_status.py
@@ -1,0 +1,31 @@
+"""Status record for a headless session, persisted so the CLI can check in."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# Lifecycle states a headless session moves through.
+STARTING = 'starting'
+LOADING_MODEL = 'loading_model'
+DOWNLOADING = 'downloading'
+RECORDING = 'recording'
+DIGESTING = 'digesting'
+STOPPED = 'stopped'
+ERROR = 'error'
+
+# States that imply a live process should be running; if the PID is dead while
+# in one of these, the session crashed.
+LIVE_STATES = frozenset({STARTING, LOADING_MODEL, DOWNLOADING, RECORDING, DIGESTING})
+
+
+@dataclass
+class SessionStatus:
+    """Mutable snapshot of a headless session's progress."""
+
+    state: str
+    pid: int
+    started_at: str
+    updated_at: str
+    segment_count: int = 0
+    digest_count: int = 0
+    error: str = ''

--- a/src/lazy_take_notes/l3_interface_adapters/gateways/coreaudio_tap_source.py
+++ b/src/lazy_take_notes/l3_interface_adapters/gateways/coreaudio_tap_source.py
@@ -51,6 +51,10 @@ class CoreAudioTapSource:
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             stdin=subprocess.PIPE,
+            # Own session so a terminal Ctrl-C (SIGINT to the foreground group)
+            # doesn't kill the tap mid-read in headless mode. We stop it via
+            # close(); the TUI is unaffected (raw mode never sends SIGINT).
+            start_new_session=True,
         )
         log.info('coreaudio-tap started (pid=%d, binary=%s)', self._proc.pid, _BINARY)
         self._thread = threading.Thread(target=self._reader, daemon=True)

--- a/src/lazy_take_notes/l3_interface_adapters/gateways/session_reader.py
+++ b/src/lazy_take_notes/l3_interface_adapters/gateways/session_reader.py
@@ -1,0 +1,59 @@
+"""Read-only access to saved session directories on disk.
+
+Shared by the session picker (TUI), the ``view`` command, and the read-only
+``ls`` / ``transcript`` / ``notes`` CLI commands. Sessions are timestamped
+subdirectories; lexical sort on the timestamp-prefixed name equals
+chronological order, so the newest session is the current one.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from lazy_take_notes.l1_entities.session_files import NOTES, TRANSCRIPT
+
+
+@dataclass(frozen=True)
+class SessionInfo:
+    """A saved session directory and what it contains."""
+
+    dir: Path
+    name: str
+    has_notes: bool
+
+
+def list_sessions(base_dir: Path) -> list[SessionInfo]:
+    """Return sessions under *base_dir*, newest-first.
+
+    A session is any subdirectory containing a transcript file (current or
+    legacy name). Sort is lexical on the directory name, which equals
+    chronological order because names are timestamp-prefixed.
+    """
+    if not base_dir.exists():
+        return []
+
+    sessions = []
+    for child in sorted(base_dir.iterdir(), reverse=True):
+        if not child.is_dir() or not TRANSCRIPT.resolve(child):
+            continue
+        sessions.append(SessionInfo(dir=child, name=child.name, has_notes=NOTES.resolve(child) is not None))
+    return sessions
+
+
+def latest_session(base_dir: Path) -> SessionInfo | None:
+    """Return the most recent session, or None when there are none."""
+    sessions = list_sessions(base_dir)
+    return sessions[0] if sessions else None
+
+
+def read_transcript(session_dir: Path) -> str | None:
+    """Return the transcript text for *session_dir*, or None if absent."""
+    path = TRANSCRIPT.resolve(session_dir)
+    return path.read_text(encoding='utf-8') if path else None
+
+
+def read_notes(session_dir: Path) -> str | None:
+    """Return the notes markdown for *session_dir*, or None if absent."""
+    path = NOTES.resolve(session_dir)
+    return path.read_text(encoding='utf-8') if path else None

--- a/src/lazy_take_notes/l3_interface_adapters/gateways/session_status.py
+++ b/src/lazy_take_notes/l3_interface_adapters/gateways/session_status.py
@@ -1,0 +1,54 @@
+"""Read/write the headless-session status file and check process liveness."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from dataclasses import asdict
+from pathlib import Path
+
+from lazy_take_notes.l1_entities.session_status import SessionStatus
+
+STATUS_FILE = '.status.json'
+
+
+def write_status(session_dir: Path, status: SessionStatus) -> Path:
+    """Atomically write *status* to ``<session_dir>/.status.json``."""
+    path = session_dir / STATUS_FILE
+    tmp = session_dir / (STATUS_FILE + '.tmp')
+    tmp.write_text(json.dumps(asdict(status)), encoding='utf-8')
+    tmp.replace(path)
+    return path
+
+
+def read_status(session_dir: Path) -> SessionStatus | None:
+    """Return the session's status, or None if absent or unreadable."""
+    path = session_dir / STATUS_FILE
+    if not path.exists():
+        return None
+    try:
+        return SessionStatus(**json.loads(path.read_text(encoding='utf-8')))
+    except (OSError, ValueError, TypeError):
+        return None
+
+
+def is_pid_alive(pid: int) -> bool:
+    """Return True if *pid* names a running process.
+
+    Used to tell a still-running session apart from one that crashed without
+    updating its status file.
+    """
+    if not isinstance(pid, int) or pid <= 0:  # guards a corrupt status file (e.g. pid stored as a string)
+        return False
+    if sys.platform == 'win32':  # pragma: no cover -- liveness check is POSIX-only; assume alive on Windows
+        return True
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:  # exists but owned by another user
+        return True
+    except OSError:
+        return False
+    return True

--- a/src/lazy_take_notes/l3_interface_adapters/gateways/subprocess_whisper_transcriber.py
+++ b/src/lazy_take_notes/l3_interface_adapters/gateways/subprocess_whisper_transcriber.py
@@ -18,6 +18,14 @@ def _subprocess_entry(model_path: str, conn: Any) -> None:
     Permanently redirects C-level stdout/stderr to /dev/null so whisper.cpp's
     fprintf() calls do not escape to the parent TUI.
     """
+    # Detach into our own session so a terminal Ctrl-C (SIGINT to the foreground
+    # process group) can't kill this worker mid-transcribe in headless mode. The
+    # parent owns our shutdown via the None sentinel / terminate().
+    try:
+        os.setsid()
+    except OSError:  # pragma: no cover -- already a session leader (rare for spawn children)
+        pass
+
     devnull = os.open(os.devnull, os.O_WRONLY)
     os.dup2(devnull, 1)
     os.dup2(devnull, 2)

--- a/src/lazy_take_notes/l4_frameworks_and_drivers/cli.py
+++ b/src/lazy_take_notes/l4_frameworks_and_drivers/cli.py
@@ -10,6 +10,19 @@ from pathlib import Path
 import click
 
 from lazy_take_notes import __version__
+from lazy_take_notes.l1_entities.session_status import LIVE_STATES
+from lazy_take_notes.l3_interface_adapters.gateways.session_reader import (
+    SessionInfo,
+    latest_session,
+    list_sessions,
+    read_notes,
+    read_transcript,
+)
+from lazy_take_notes.l3_interface_adapters.gateways.session_status import (
+    STATUS_FILE,
+    is_pid_alive,
+    read_status,
+)
 from lazy_take_notes.l4_frameworks_and_drivers.cli_helpers import (
     load_config as _load_config,
 )
@@ -108,6 +121,18 @@ def cli(ctx, config_path, output_dir):
             return
 
 
+def _check_template_language(template_name, language) -> None:
+    """Reject the ambiguous combination of --template and --language."""
+    if template_name and language:
+        raise click.ClickException('Use --template or --language, not both.')
+
+
+def _require_headless_template(template_name, language) -> None:
+    """Headless has no picker, so the language must be explicit (no silent default)."""
+    if not template_name and not language:
+        raise click.ClickException('--headless requires --language (e.g. --language en) or --template.')
+
+
 @cli.command()
 @click.option(
     '-l',
@@ -115,14 +140,37 @@ def cli(ctx, config_path, output_dir):
     default=None,
     help="Session label appended to the timestamp folder (e.g. 'sprint-review').",
 )
+@click.option('--headless', is_flag=True, help='Run without the TUI; write files only. Track it with `status`.')
+@click.option(
+    '--template',
+    'template_name',
+    default=None,
+    help='Template key, e.g. lecture_notes_en. Skips the picker.',
+)
+@click.option(
+    '--language',
+    default=None,
+    help="Language/locale, e.g. en or zh-TW. Uses that locale's default template.",
+)
+@click.option('--mute-mic', is_flag=True, help='Start with the microphone muted (capture system audio only).')
 @click.pass_context
-def record(ctx, label):
+def record(ctx, label, headless, template_name, language, mute_mic):
     """Start a live recording session with transcription and digest."""
+    _check_template_language(template_name, language)
+    if headless:
+        _require_headless_template(template_name, language)
+        from lazy_take_notes.l4_frameworks_and_drivers.headless import (  # noqa: PLC0415 -- deferred: not loaded on --help
+            run_record_headless,
+        )
+
+        run_record_headless(ctx, template_name=template_name, language=language, label=label, mute_mic=mute_mic)
+        return
+
     from lazy_take_notes.l4_frameworks_and_drivers.cli_helpers import (  # noqa: PLC0415 -- deferred: not loaded on --help
         run_record as _run_record_impl,
     )
 
-    _run_record_impl(ctx, label=label)
+    _run_record_impl(ctx, label=label, template_name=template_name, language=language, mute_mic=mute_mic)
 
 
 @cli.command()
@@ -133,9 +181,26 @@ def record(ctx, label):
     default=None,
     help="Session label appended to the timestamp folder (e.g. 'sprint-review').",
 )
+@click.option('--headless', is_flag=True, help='Run without the TUI; write files only. Track it with `status`.')
+@click.option(
+    '--template',
+    'template_name',
+    default=None,
+    help='Template key, e.g. lecture_notes_en. Skips the picker.',
+)
+@click.option(
+    '--language',
+    default=None,
+    help="Language/locale, e.g. en or zh-TW. Uses that locale's default template.",
+)
 @click.pass_context
-def transcribe(ctx, audio_file, label):
+def transcribe(ctx, audio_file, label, headless, template_name, language):
     """Transcribe an audio file with streaming TUI and generate a final digest."""
+    _check_template_language(template_name, language)
+    if headless:
+        if audio_file is None:
+            raise click.ClickException('--headless requires an audio file argument (no interactive picker).')
+        _require_headless_template(template_name, language)
     if audio_file is None:
         from lazy_take_notes.l4_frameworks_and_drivers.pickers.file_picker import (  # noqa: PLC0415 -- deferred: Textual not loaded on --help
             FilePicker,
@@ -150,7 +215,17 @@ def transcribe(ctx, audio_file, label):
         click.echo(f'Error: {audio_file!r} is not a valid file.', err=True)
         sys.exit(1)
 
-    _run_transcribe(ctx, audio_path=Path(audio_file), label=label)
+    if headless:
+        from lazy_take_notes.l4_frameworks_and_drivers.headless import (  # noqa: PLC0415 -- deferred: not loaded on --help
+            run_transcribe_headless,
+        )
+
+        run_transcribe_headless(
+            ctx, audio_path=Path(audio_file), template_name=template_name, language=language, label=label
+        )
+        return
+
+    _run_transcribe(ctx, audio_path=Path(audio_file), label=label, template_name=template_name, language=language)
 
 
 @cli.command()
@@ -179,6 +254,139 @@ def view(ctx):
 
         app = ViewApp(session_dir=session_dir)
         app.run()
+
+
+_LS_DEFAULT_LIMIT = 20
+
+
+def _read_base_dir(ctx) -> Path:
+    """Resolve the base sessions directory from config + CLI overrides."""
+    config_path = ctx.obj['config_path']
+    output_dir = ctx.obj['output_dir']
+    config, _infra, _template_loader = _load_config(config_path, output_dir)
+    return _resolve_base_dir(output_dir, config)
+
+
+def _match_by_name(items, name: str, noun: str):
+    """Pick the item whose ``.name`` matches: exact first, then unique substring.
+
+    Raises ClickException when nothing matches or the name is ambiguous. Items
+    can be SessionInfo or Path — both expose ``.name``.
+    """
+    exact = [i for i in items if i.name == name]
+    if exact:
+        return exact[0]
+    matches = [i for i in items if name in i.name]
+    if len(matches) == 1:
+        return matches[0]
+    if not matches:
+        raise click.ClickException(f'No {noun} matching {name!r}.')
+    raise click.ClickException(f'{name!r} matches multiple sessions: ' + ', '.join(i.name for i in matches))
+
+
+def _resolve_session(base_dir: Path, name: str | None) -> SessionInfo:
+    """Resolve a session by name, falling back to the newest one."""
+    if name is None:
+        latest = latest_session(base_dir)
+        if latest is None:
+            raise click.ClickException('No sessions found.')
+        return latest
+    return _match_by_name(list_sessions(base_dir), name, 'session')
+
+
+def _emit_session_text(ctx, name: str | None, reader, kind: str) -> None:
+    """Print a session artifact to stdout, or exit with an error."""
+    info = _resolve_session(_read_base_dir(ctx), name)
+    text = reader(info.dir)
+    if text is None:
+        raise click.ClickException(f'Session {info.name!r} has no {kind}.')
+    click.echo(text, nl=False)
+
+
+@cli.command('ls')
+@click.option('--json', 'as_json', is_flag=True, help='Output as JSON for scripting (all sessions).')
+@click.option(
+    '-a',
+    '--all',
+    'show_all',
+    is_flag=True,
+    help=f'Show every session instead of the newest {_LS_DEFAULT_LIMIT}.',
+)
+@click.pass_context
+def list_command(ctx, as_json, show_all):
+    """List saved sessions, newest first (newest 20 by default)."""
+    sessions = list_sessions(_read_base_dir(ctx))
+    if as_json:
+        import json  # noqa: PLC0415 -- deferred: only needed for --json
+
+        payload = [{'name': s.name, 'dir': str(s.dir), 'has_notes': s.has_notes} for s in sessions]
+        click.echo(json.dumps(payload))
+        return
+    if not sessions:
+        click.echo('No sessions found.')
+        return
+    shown = sessions if show_all else sessions[:_LS_DEFAULT_LIMIT]
+    for session in shown:
+        marker = 'notes' if session.has_notes else '   -'
+        click.echo(f'{marker}  {session.name}')
+    hidden = len(sessions) - len(shown)
+    if hidden:
+        click.echo(f'... {hidden} more (use -a/--all to show every session)', err=True)
+
+
+@cli.command()
+@click.argument('session', required=False, default=None)
+@click.pass_context
+def transcript(ctx, session):
+    """Print a session's transcript (newest session by default)."""
+    _emit_session_text(ctx, session, read_transcript, 'transcript')
+
+
+@cli.command()
+@click.argument('session', required=False, default=None)
+@click.pass_context
+def notes(ctx, session):
+    """Print a session's notes (newest session by default)."""
+    _emit_session_text(ctx, session, read_notes, 'notes')
+
+
+def _resolve_status_dir(base_dir: Path, name: str | None) -> Path:
+    """Find a session directory that has a status file (newest by default)."""
+    candidates = (
+        [c for c in sorted(base_dir.iterdir(), reverse=True) if c.is_dir() and (c / STATUS_FILE).exists()]
+        if base_dir.exists()
+        else []
+    )
+    if not candidates:
+        raise click.ClickException('No headless session found.')
+    if name is None:
+        return candidates[0]
+    return _match_by_name(candidates, name, 'headless session')
+
+
+@cli.command()
+@click.argument('session', required=False, default=None)
+@click.pass_context
+def status(ctx, session):
+    """Show a headless session's status (newest by default)."""
+    session_dir = _resolve_status_dir(_read_base_dir(ctx), session)
+    state = read_status(session_dir)
+    if state is None:
+        raise click.ClickException(f'Status file for {session_dir.name!r} is missing or unreadable.')
+
+    display = state.state
+    if state.state in LIVE_STATES and not is_pid_alive(state.pid):
+        display = f'{state.state} (crashed — process {state.pid} not running)'
+
+    click.echo(f'session:  {session_dir.name}')
+    click.echo(f'state:    {display}')
+    click.echo(f'pid:      {state.pid}')
+    click.echo(f'segments: {state.segment_count}')
+    click.echo(f'digests:  {state.digest_count}')
+    click.echo(f'started:  {state.started_at}')
+    click.echo(f'updated:  {state.updated_at}')
+    if state.error:
+        click.echo(f'error:    {state.error}')
 
 
 @cli.command('create-template')

--- a/src/lazy_take_notes/l4_frameworks_and_drivers/cli_helpers.py
+++ b/src/lazy_take_notes/l4_frameworks_and_drivers/cli_helpers.py
@@ -137,6 +137,51 @@ def preflight_llm(infra, config) -> tuple[list[str], list[str]]:
     return missing_digest, missing_interactive
 
 
+def load_template_key(template_loader, key: str):
+    """Load a template by its exact key, or stop with the available keys listed."""
+    try:
+        return template_loader.load(key)
+    except FileNotFoundError:
+        available = ', '.join(t.key for t in template_loader.list_templates())
+        raise click.ClickException(f'Unknown template {key!r}. Available: {available}') from None
+
+
+def resolve_language(template_loader, language: str):
+    """Return the default template for a locale, or stop if the language is unsupported.
+
+    Matches the full locale first (e.g. ``zh-TW``), then falls back to the
+    primary subtag when unambiguous (so ``en-US`` -> ``en``). Stays fail-loud:
+    an unknown or ambiguous language (e.g. ``zh`` with both zh-TW and zh-min-nan)
+    raises with the available list.
+    """
+    defaults = {t.locale.lower(): t for t in template_loader.list_templates() if t.key.startswith('default_')}
+    key = language.lower()
+    meta = defaults.get(key)
+    if meta is None:
+        primary = key.split('-')[0]
+        subtag_matches = [m for locale, m in defaults.items() if locale.split('-')[0] == primary]
+        meta = subtag_matches[0] if len(subtag_matches) == 1 else None
+    if meta is None:
+        available = ', '.join(sorted(t.locale for t in defaults.values()))
+        raise click.ClickException(f'Unsupported language {language!r}. Available: {available}')
+    return template_loader.load(meta.key)
+
+
+def select_template(template_loader, *, template_name, language, show_builtins):
+    """Resolve a template from --language / --template, or fall back to the picker."""
+    if language:
+        return resolve_language(template_loader, language)
+    if template_name:
+        return load_template_key(template_loader, template_name)
+    return pick_template(template_loader, show_builtins=show_builtins)
+
+
+def set_mic_muted(audio_source, muted: bool) -> None:
+    """Set mic-mute state on a source that supports it; no-op otherwise."""
+    if hasattr(audio_source, 'mic_muted'):
+        audio_source.mic_muted = muted
+
+
 def run_transcribe(
     ctx: click.Context,
     *,
@@ -145,6 +190,8 @@ def run_transcribe(
     label: str | None = None,
     llm_client: LLMClient | None = None,
     transcriber: Transcriber | None = None,
+    template_name: str | None = None,
+    language: str | None = None,
 ) -> None:
     """Run a complete transcription session — the high-level plugin entry point.
 
@@ -168,7 +215,9 @@ def run_transcribe(
     output_dir = ctx.obj['output_dir']
     config, infra, template_loader = load_config(config_path, output_dir)
 
-    template = pick_template(template_loader, show_builtins=infra.show_builtin_templates)
+    template = select_template(
+        template_loader, template_name=template_name, language=language, show_builtins=infra.show_builtin_templates
+    )
     if template is None:
         return
 
@@ -224,6 +273,9 @@ def run_record(
     llm_client: LLMClient | None = None,
     transcriber: Transcriber | None = None,
     audio_source: AudioSource | None = None,
+    template_name: str | None = None,
+    language: str | None = None,
+    mute_mic: bool = False,
 ) -> None:
     """Run a live recording session -- the high-level plugin entry point.
 
@@ -245,7 +297,9 @@ def run_record(
     output_dir = ctx.obj['output_dir']
     config, infra, template_loader = load_config(config_path, output_dir)
 
-    template = pick_template(template_loader, show_builtins=infra.show_builtin_templates)
+    template = select_template(
+        template_loader, template_name=template_name, language=language, show_builtins=infra.show_builtin_templates
+    )
     if template is None:
         return
 
@@ -265,6 +319,8 @@ def run_record(
         transcriber=transcriber,
         audio_source=audio_source,
     )
+    if mute_mic:
+        set_mic_muted(container.audio_source, True)
     app = RecordApp(
         config=config,
         template=template,
@@ -277,4 +333,10 @@ def run_record(
         missing_interactive_models=missing_interactive,
         label=label or '',
     )
-    app.run()
+
+    from lazy_take_notes.l4_frameworks_and_drivers.keep_awake import (  # noqa: PLC0415 -- deferred: not loaded on --help
+        keep_awake,
+    )
+
+    with keep_awake():
+        app.run()

--- a/src/lazy_take_notes/l4_frameworks_and_drivers/headless.py
+++ b/src/lazy_take_notes/l4_frameworks_and_drivers/headless.py
@@ -1,0 +1,531 @@
+"""Headless session runner — drives the workers and controller without a TUI.
+
+Reuses the same worker functions and ``SessionController`` as the Textual apps.
+A worker runs in a background thread and posts messages through a thread-safe
+sink into an asyncio queue drained on the main thread, so all controller
+mutation stays single-threaded — the same invariant the TUI relies on.
+
+Output is files only (transcript + notes, written by the controller). Progress
+is exposed through a ``.status.json`` file that the ``status`` CLI command reads.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import signal
+import sys
+import threading
+from collections.abc import Callable
+from datetime import datetime
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import click
+
+from lazy_take_notes.l1_entities import session_status as st
+from lazy_take_notes.l1_entities.session_files import NOTES, TRANSCRIPT
+from lazy_take_notes.l1_entities.session_status import SessionStatus
+from lazy_take_notes.l3_interface_adapters.gateways.session_status import write_status
+from lazy_take_notes.l4_frameworks_and_drivers.cli_helpers import (
+    load_config,
+    load_template_key,
+    make_session_dir,
+    preflight_llm,
+    preflight_microphone,
+    resolve_base_dir,
+    resolve_language,
+    set_mic_muted,
+)
+from lazy_take_notes.l4_frameworks_and_drivers.messages import (
+    AudioWorkerStatus,
+    ModelDownloadProgress,
+    TranscriptChunk,
+)
+
+if TYPE_CHECKING:
+    from lazy_take_notes.l3_interface_adapters.controllers.session_controller import SessionController
+
+log = logging.getLogger('ltn.headless')
+
+HEARTBEAT_INTERVAL = 60.0
+
+# After a stop is requested, don't wait forever for a wedged worker to post
+# 'stopped' — give up after this grace period so Ctrl-C always returns control.
+STOP_GRACE = 30.0
+
+# Worker status string -> our session state.
+_WORKER_STATE = {
+    'loading_model': st.LOADING_MODEL,
+    'model_ready': st.RECORDING,
+    'recording': st.RECORDING,
+    'warning': st.RECORDING,
+}
+
+
+def _now() -> str:
+    return datetime.now().isoformat(timespec='seconds')
+
+
+class _StatusWriter:
+    """Renders permanent log lines plus a single in-place status (heartbeat) line.
+
+    On a TTY the heartbeat rewrites one line in place via ``\\r``. A permanent
+    line first commits whatever heartbeat is currently shown (a ``\\n`` leaves
+    that last snapshot in scrollback) and prints below it, so milestones never
+    overwrite live status and the status line never shows stale numbers — the
+    committed snapshot was accurate when it was frozen, and the next heartbeat
+    starts a fresh in-place line. When the stream is not a TTY (piped / log
+    file) the heartbeat is suppressed; liveness comes from the milestone lines
+    and the ``status`` command, keeping logs clean.
+    """
+
+    def __init__(self, stream) -> None:
+        self._stream = stream
+        self._tty = stream.isatty()
+        self._pending = False  # an in-place heartbeat line is currently shown
+
+    def line(self, message: str) -> None:
+        if self._tty and self._pending:
+            self._stream.write('\n')  # commit the in-place heartbeat snapshot as-is
+            self._pending = False
+        self._stream.write(message + '\n')
+        self._stream.flush()
+
+    def status(self, message: str) -> None:
+        if not self._tty:
+            return
+        self._stream.write(f'\r{message}\x1b[K')
+        self._pending = True
+        self._stream.flush()
+
+    def finish(self) -> None:
+        if self._tty and self._pending:
+            self._stream.write('\n')
+            self._stream.flush()
+            self._pending = False
+
+
+def _clock(seconds: float) -> str:
+    total = max(int(seconds), 0)
+    minutes, secs = divmod(total, 60)
+    return f'{minutes:02d}:{secs:02d}'
+
+
+def _heartbeat_line(activity: str, elapsed: float, segments: int, digests: int) -> str:
+    plural = '' if digests == 1 else 's'
+    return f'⏺ {activity} · {_clock(elapsed)} · {segments} seg · {digests} digest{plural}'
+
+
+def _banner_lines(activity: str, out_dir: Path, pid: int, *, show_mute: bool = False) -> list[str]:
+    lines = [
+        f'▶ {activity} → {out_dir}',
+        f'  stop:  Ctrl-C  (or kill -INT {pid})',
+    ]
+    if show_mute:
+        lines.append(f'  mute:  kill -USR1 {pid}')
+    lines.append('  check: lazy-take-notes status')
+    return lines
+
+
+def _iso_elapsed(start_iso: str, end_iso: str) -> float:
+    try:
+        return (datetime.fromisoformat(end_iso) - datetime.fromisoformat(start_iso)).total_seconds()
+    except ValueError:  # pragma: no cover -- timestamps always ISO from _now()
+        return 0.0
+
+
+def _summary_lines(out_dir: Path, status: SessionStatus) -> list[str]:
+    plural = '' if status.digest_count == 1 else 's'
+    clock = _clock(_iso_elapsed(status.started_at, status.updated_at))
+    head = f'■ {status.state} · {clock} · {status.segment_count} seg · {status.digest_count} digest{plural}'
+    lines = [head]
+    if status.segment_count:
+        lines.append(f'  transcript: {out_dir / TRANSCRIPT.name}')
+    if status.digest_count:
+        lines.append(f'  notes:      {out_dir / NOTES.name}')
+    if status.error:
+        lines.append(f'  error:      {status.error}')
+    return lines
+
+
+class HeadlessSession:
+    """Pumps worker messages into the controller and tracks status on disk.
+
+    *worker_launcher* is a blocking callable ``(post_message, is_cancelled)``
+    run in a background thread; it drives one of the existing worker functions.
+    """
+
+    def __init__(
+        self,
+        controller: SessionController,
+        output_dir: Path,
+        worker_launcher: Callable[[Callable, Callable[[], bool]], None],
+        report: Callable[[str], None] | None = None,
+        activity: str = 'recording',
+        audio_source=None,
+        status_sink: Callable[[str], None] | None = None,
+    ) -> None:
+        self._controller = controller
+        self._output_dir = Path(output_dir)
+        self._launch_worker = worker_launcher
+        self._writer = _StatusWriter(sys.stderr)
+        self._report = report or self._writer.line
+        self._status_sink = status_sink or self._writer.status
+        self._activity = activity
+        self._audio_source = audio_source
+        self._last_dl_bucket = -1
+        self._last_warning: str | None = None
+        self._started = False  # worker reached model_ready/recording
+        self._cancel = threading.Event()
+        self._status = SessionStatus(
+            state=st.STARTING,
+            pid=os.getpid(),
+            started_at=_now(),
+            updated_at=_now(),
+        )
+
+    @property
+    def status(self) -> SessionStatus:
+        return self._status
+
+    def request_stop(self) -> None:
+        """Signal the worker to wind down (wired to SIGINT)."""
+        if not self._cancel.is_set():
+            self._report('⏹ stopping… finishing the current chunk, then the final digest')
+        self._cancel.set()
+
+    def _elapsed_seconds(self) -> float:
+        return _iso_elapsed(self._status.started_at, _now())
+
+    def _save(self, state: str | None = None, error: str | None = None) -> None:
+        if state is not None:
+            self._status.state = state
+        if error is not None:
+            self._status.error = error
+        self._status.segment_count = len(self._controller.all_segments)
+        self._status.digest_count = self._controller.digest_state.digest_count
+        self._status.updated_at = _now()
+        write_status(self._output_dir, self._status)
+
+    async def run(self) -> None:
+        loop = asyncio.get_running_loop()
+        queue: asyncio.Queue = asyncio.Queue()
+
+        def sink(message) -> None:
+            loop.call_soon_threadsafe(queue.put_nowait, message)
+
+        self._install_signal_handler(loop)
+        self._install_mic_toggle(loop)
+        self._save()
+
+        thread = threading.Thread(
+            target=self._launch_worker,
+            args=(sink, self._cancel.is_set),
+            daemon=True,
+        )
+        thread.start()
+
+        beat = asyncio.create_task(self._heartbeat(HEARTBEAT_INTERVAL))
+        try:
+            await self._pump(queue)
+            thread.join(timeout=5)
+            await self._finalize()
+        except Exception as exc:
+            log.error('headless session aborted: %s', exc, exc_info=True)
+            try:
+                self._save(state=st.ERROR, error=str(exc))
+            except Exception:  # noqa: S110 -- best-effort; original error matters # pragma: no cover
+                pass
+            raise
+        finally:
+            beat.cancel()
+            self._writer.finish()
+
+    async def _heartbeat(self, interval: float) -> None:
+        while True:
+            await asyncio.sleep(interval)
+            self._status_sink(
+                _heartbeat_line(
+                    self._activity,
+                    self._elapsed_seconds(),
+                    len(self._controller.all_segments),
+                    self._controller.digest_state.digest_count,
+                )
+            )
+
+    def _install_signal_handler(self, loop: asyncio.AbstractEventLoop) -> None:
+        try:
+            loop.add_signal_handler(signal.SIGINT, self.request_stop)
+        except (NotImplementedError, RuntimeError):  # pragma: no cover -- platform fallback (e.g. Windows)
+            signal.signal(signal.SIGINT, lambda *_: self.request_stop())
+
+    def _install_mic_toggle(self, loop: asyncio.AbstractEventLoop) -> None:
+        if self._audio_source is None:
+            return
+        if not hasattr(signal, 'SIGUSR1'):  # pragma: no cover -- non-POSIX (e.g. Windows)
+            return
+        try:
+            loop.add_signal_handler(signal.SIGUSR1, self._toggle_mic)
+        except (NotImplementedError, RuntimeError):  # pragma: no cover -- platform fallback
+            signal.signal(signal.SIGUSR1, lambda *_: self._toggle_mic())
+
+    def _toggle_mic(self) -> None:
+        muted = not getattr(self._audio_source, 'mic_muted', False)
+        set_mic_muted(self._audio_source, muted)
+        self._report('⏸ mic muted' if muted else '▶ mic unmuted')
+
+    async def _pump(self, queue: asyncio.Queue) -> None:
+        while True:
+            try:
+                # After a stop request, don't block forever on a wedged worker.
+                timeout = STOP_GRACE if self._cancel.is_set() else None
+                message = await asyncio.wait_for(queue.get(), timeout)
+            except TimeoutError:
+                self._report('⏹ worker did not stop in time; ending session')
+                return
+            if isinstance(message, TranscriptChunk):
+                await self._on_chunk(message)
+            elif isinstance(message, AudioWorkerStatus):
+                if message.status == 'stopped':
+                    return
+                if message.status == 'error':
+                    if self._handle_error(message):
+                        return  # fatal -> stop the pump
+                    continue  # recoverable -> keep recording
+                if message.status in ('model_ready', 'recording'):
+                    self._started = True
+                if message.status == 'warning':
+                    if message.error != self._last_warning:
+                        self._report(f'⚠ {message.error}')
+                        self._last_warning = message.error
+                else:
+                    self._report_status(message.status)
+                self._save(state=_WORKER_STATE.get(message.status, self._status.state))
+            elif isinstance(message, ModelDownloadProgress):
+                self._report_download(message)
+                self._save(state=st.DOWNLOADING)
+            # TranscriptionStatus / AudioLevel carry no headless-relevant state.
+
+    def _handle_error(self, message: AudioWorkerStatus) -> bool:
+        """Handle a worker 'error'. Returns True if the session should stop.
+
+        The audio worker emits 'error' for both fatal startup failures (model
+        load / device init, before recording begins) and recoverable mid-session
+        failures (e.g. a single chunk failed to transcribe — the worker keeps
+        recording). A recoverable error must NOT end the session, matching the
+        TUI which only notifies and carries on.
+        """
+        if self._cancel.is_set():
+            # Teardown noise during a user-requested stop — log, then finalize cleanly.
+            log.info('worker error during shutdown: %s', message.error)
+            return True
+        if not self._started:
+            self._report(f'✗ error: {message.error}')
+            self._save(state=st.ERROR, error=message.error)
+            return True
+        self._report(f'✗ transcription error (continuing): {message.error}')
+        return False
+
+    def _report_status(self, status: str) -> None:
+        if status == 'loading_model':
+            self._report('… loading model')
+        elif status == 'recording':
+            self._report(f'✓ model ready, {self._activity}')
+
+    def _report_download(self, message: ModelDownloadProgress) -> None:
+        bucket = message.percent // 20
+        if bucket != self._last_dl_bucket:
+            self._last_dl_bucket = bucket
+            self._report(f'… downloading {message.model_name} {message.percent}%')
+
+    async def _on_chunk(self, message: TranscriptChunk) -> None:
+        self._last_warning = None  # audio is flowing again — let a later loss warn afresh
+        should_digest = self._controller.on_transcript_segments(message.segments)
+        if should_digest:
+            await self._digest(is_final=False)
+        else:
+            self._save(state=st.RECORDING)
+
+    async def _digest(self, *, is_final: bool) -> None:
+        self._save(state=st.DIGESTING)
+        result = await self._controller.run_digest(is_final=is_final)
+        if result.data is not None:
+            self._report(f'✓ notes.md updated (digest #{self._controller.digest_state.digest_count})')
+            self._save(state=st.RECORDING)
+        else:
+            error = result.error or 'digest failed'
+            self._report(f'✗ digest failed: {error}')
+            self._save(state=st.RECORDING, error=error)
+
+    async def _finalize(self) -> None:
+        if self._status.state == st.ERROR:
+            return
+        state = self._controller.digest_state
+        if state.buffer or state.digest_count > 0:
+            await self._digest(is_final=True)
+        self._save(state=st.STOPPED)
+
+
+def _shared_worker_kwargs(config, template) -> dict:
+    """Transcription kwargs common to both the live-audio and file workers."""
+    tc = config.transcription
+    return {
+        'language': template.metadata.locale.split('-')[0].lower(),
+        'chunk_duration': tc.chunk_duration,
+        'overlap': tc.overlap,
+        'silence_threshold': tc.silence_threshold,
+        'pause_duration': tc.pause_duration,
+        'recognition_hints': list(dict.fromkeys(config.recognition_hints + template.recognition_hints)),
+    }
+
+
+def _audio_launcher(config, template, output_dir, model_resolver_factory, transcriber, audio_source):
+    """Build the blocking launcher that runs the live audio worker."""
+
+    def launch(post_message, is_cancelled):  # pragma: no cover -- thread body; drives real audio/whisper
+        from lazy_take_notes.l3_interface_adapters.gateways.hf_model_resolver import (  # noqa: PLC0415 -- deferred: fallback resolver
+            HfModelResolver,
+        )
+        from lazy_take_notes.l4_frameworks_and_drivers.workers.audio_worker import (  # noqa: PLC0415 -- deferred: audio stack loaded only when session starts
+            run_audio_worker,
+        )
+
+        model_name = config.transcription.model_for_locale(template.metadata.locale)
+
+        def on_progress(percent: int) -> None:
+            post_message(ModelDownloadProgress(percent=percent, model_name=model_name))
+
+        try:
+            resolver = (model_resolver_factory or (lambda cb: HfModelResolver(on_progress=cb)))(on_progress)
+            model_path = resolver.resolve(model_name)
+        except Exception as exc:  # noqa: BLE001 -- surface model-resolution failure as a worker error
+            post_message(AudioWorkerStatus(status='error', error=str(exc)))
+            return
+
+        run_audio_worker(
+            post_message=post_message,
+            is_cancelled=is_cancelled,
+            model_path=model_path,
+            output_dir=output_dir,
+            save_audio=config.output.save_audio,
+            transcriber=transcriber,
+            audio_source=audio_source,
+            **_shared_worker_kwargs(config, template),
+        )
+
+    return launch
+
+
+def _file_launcher(config, template, audio_path, model_resolver_factory, transcriber):
+    """Build the blocking launcher that transcribes an audio file."""
+
+    def launch(post_message, is_cancelled):  # pragma: no cover -- thread body; drives ffmpeg/whisper
+        from lazy_take_notes.l4_frameworks_and_drivers.workers.file_transcription_worker import (  # noqa: PLC0415 -- deferred: loaded only when session starts
+            run_file_transcription,
+        )
+
+        run_file_transcription(
+            post_message=post_message,
+            is_cancelled=is_cancelled,
+            audio_path=audio_path,
+            model_name=config.transcription.model_for_locale(template.metadata.locale),
+            transcriber=transcriber,
+            model_resolver_factory=model_resolver_factory,
+            **_shared_worker_kwargs(config, template),
+        )
+
+    return launch
+
+
+def _select_headless_template(template_loader, template_name: str | None, language: str | None):
+    """Pick the template for a headless session: --language, then --template, then default_en."""
+    if language:
+        return resolve_language(template_loader, language)
+    return load_template_key(template_loader, template_name or 'default_en')
+
+
+def _build_container(config, template, out_dir, infra, **overrides):
+    from lazy_take_notes.l4_frameworks_and_drivers.container import (  # noqa: PLC0415 -- deferred: container not loaded for --help
+        DependencyContainer,
+    )
+
+    return DependencyContainer(config, template, out_dir, infra=infra, **overrides)
+
+
+def _run(out_dir: Path, config, session: HeadlessSession) -> None:
+    from lazy_take_notes.l4_frameworks_and_drivers.logging_setup import (  # noqa: PLC0415 -- deferred
+        setup_file_logging,
+    )
+
+    setup_file_logging(out_dir, enabled=config.output.save_debug_log)
+    asyncio.run(session.run())
+    for line in _summary_lines(out_dir, session.status):
+        click.echo(line, err=True)
+    click.echo(str(out_dir))
+
+
+def _emit_banner(activity: str, out_dir: Path, pid: int, *, show_mute: bool = False) -> None:
+    for line in _banner_lines(activity, out_dir, pid, show_mute=show_mute):
+        click.echo(line, err=True)
+
+
+def _warn_missing_models(missing_digest: list[str], missing_interactive: list[str]) -> None:
+    """Warn up front about reachable-but-unavailable models (headless has no TUI to show them)."""
+    for model in dict.fromkeys([*missing_digest, *missing_interactive]):
+        click.echo(f'⚠ model not available: {model} (cycles using it will fail)', err=True)
+
+
+def run_record_headless(
+    ctx: click.Context,
+    *,
+    template_name: str | None = None,
+    language: str | None = None,
+    label: str | None = None,
+    mute_mic: bool = False,
+) -> None:
+    """Run a live recording session headlessly (no TUI)."""
+    from lazy_take_notes.l4_frameworks_and_drivers.keep_awake import keep_awake  # noqa: PLC0415 -- deferred
+
+    config, infra, template_loader = load_config(ctx.obj['config_path'], ctx.obj['output_dir'])
+    template = _select_headless_template(template_loader, template_name, language)
+
+    out_dir = make_session_dir(resolve_base_dir(ctx.obj['output_dir'], config), label)
+    _warn_missing_models(*preflight_llm(infra, config))
+    preflight_microphone()
+
+    container = _build_container(config, template, out_dir, infra)
+    if mute_mic:
+        set_mic_muted(container.audio_source, True)
+    launcher = _audio_launcher(
+        config, template, out_dir, container.model_resolver_factory, container.transcriber, container.audio_source
+    )
+    session = HeadlessSession(
+        container.controller, out_dir, launcher, activity='recording', audio_source=container.audio_source
+    )
+    _emit_banner('recording', out_dir, session.status.pid, show_mute=True)
+    with keep_awake():
+        _run(out_dir, config, session)
+
+
+def run_transcribe_headless(
+    ctx: click.Context,
+    *,
+    audio_path: Path,
+    template_name: str | None = None,
+    language: str | None = None,
+    label: str | None = None,
+) -> None:
+    """Transcribe an audio file headlessly (no TUI)."""
+    config, infra, template_loader = load_config(ctx.obj['config_path'], ctx.obj['output_dir'])
+    template = _select_headless_template(template_loader, template_name, language)
+
+    out_dir = make_session_dir(resolve_base_dir(ctx.obj['output_dir'], config), label)
+    _warn_missing_models(*preflight_llm(infra, config))
+
+    container = _build_container(config, template, out_dir, infra, build_audio=False)
+    launcher = _file_launcher(config, template, audio_path, container.model_resolver_factory, container.transcriber)
+    session = HeadlessSession(container.controller, out_dir, launcher, activity='transcribing')
+    _emit_banner('transcribing', out_dir, session.status.pid)
+    _run(out_dir, config, session)

--- a/src/lazy_take_notes/l4_frameworks_and_drivers/keep_awake.py
+++ b/src/lazy_take_notes/l4_frameworks_and_drivers/keep_awake.py
@@ -1,0 +1,46 @@
+"""Prevent the machine from sleeping while a live recording is active.
+
+macOS only (uses ``caffeinate``); a no-op on other platforms. The inhibitor is
+tied to this process via ``-w <pid>``, so the assertion is released even if the
+process is killed without a clean shutdown.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess  # noqa: S404 -- launches caffeinate with a fixed arg list, not shell=True
+import sys
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+
+def inhibit_sleep() -> subprocess.Popen | None:
+    """Start a display/idle-sleep inhibitor for this process, or None if unsupported."""
+    if sys.platform != 'darwin':
+        return None
+    try:
+        return subprocess.Popen(  # noqa: S603 -- fixed arg list, not shell=True
+            ['caffeinate', '-di', '-w', str(os.getpid())],  # noqa: S607 -- caffeinate is a macOS system binary on PATH
+            # Own session so a terminal Ctrl-C doesn't kill the inhibitor; it stays
+            # up through the graceful-stop / final-digest window and is released when
+            # this process exits (the -w pid tie), or by release_sleep().
+            start_new_session=True,
+        )
+    except (OSError, ValueError):  # pragma: no cover -- caffeinate missing or unspawnable
+        return None
+
+
+def release_sleep(handle: subprocess.Popen | None) -> None:
+    """Release a previously started inhibitor."""
+    if handle is not None:
+        handle.terminate()
+
+
+@contextmanager
+def keep_awake() -> Iterator[None]:
+    """Keep the machine (and display) awake for the duration of the block."""
+    handle = inhibit_sleep()
+    try:
+        yield
+    finally:
+        release_sleep(handle)

--- a/src/lazy_take_notes/l4_frameworks_and_drivers/pickers/session_picker.py
+++ b/src/lazy_take_notes/l4_frameworks_and_drivers/pickers/session_picker.py
@@ -8,47 +8,24 @@ from textual.app import ComposeResult
 from textual.widgets import ListItem, Markdown, Static
 
 from lazy_take_notes.l1_entities.session_files import NOTES, TRANSCRIPT
+from lazy_take_notes.l3_interface_adapters.gateways.session_reader import (
+    SessionInfo,
+    list_sessions,
+)
 from lazy_take_notes.l4_frameworks_and_drivers.pickers.base import (
     PickerListView,
     SearchablePicker,
 )
 
 
-def discover_sessions(sessions_dir: Path) -> list[dict]:
-    """Scan *sessions_dir* for session subdirs containing a transcript file.
-
-    Recognises both current and legacy filenames.
-
-    Returns a list of dicts sorted newest-first:
-      {'dir': Path, 'name': str, 'has_digest': bool}
-    """
-    if not sessions_dir.exists():
-        return []
-
-    results = []
-    for child in sorted(sessions_dir.iterdir(), reverse=True):
-        if not child.is_dir():
-            continue
-        if not TRANSCRIPT.resolve(child):
-            continue
-        results.append(
-            {
-                'dir': child,
-                'name': child.name,
-                'has_digest': NOTES.resolve(child) is not None,
-            }
-        )
-    return results
-
-
 class SessionItem(ListItem):
     """Selectable row representing a saved session."""
 
-    def __init__(self, session: dict) -> None:
+    def __init__(self, session: SessionInfo) -> None:
         super().__init__()
-        self.session_dir: Path = session['dir']
-        digest_badge = '  [green]\u2713 digest[/green]' if session['has_digest'] else '  [dim]no digest[/dim]'
-        self._label_text = f'{session["name"]}{digest_badge}'
+        self.session_dir: Path = session.dir
+        digest_badge = '  [green]\u2713 digest[/green]' if session.has_notes else '  [dim]no digest[/dim]'
+        self._label_text = f'{session.name}{digest_badge}'
 
     def compose(self) -> ComposeResult:
         yield Static(self._label_text, markup=True)
@@ -70,7 +47,7 @@ class SessionPicker(SearchablePicker[Path]):
     def __init__(self, sessions_dir: Path, **kwargs):
         super().__init__(**kwargs)
         self._sessions_dir = sessions_dir
-        self._sessions = discover_sessions(sessions_dir)
+        self._sessions = list_sessions(sessions_dir)
         self._current_session: Path | None = None
 
     def _make_list_view(self) -> _SessionListView:
@@ -94,7 +71,7 @@ class SessionPicker(SearchablePicker[Path]):
 
         first_item: SessionItem | None = None
         for session in self._sessions:
-            if query and query not in session['name'].lower():
+            if query and query not in session.name.lower():
                 continue
             item = SessionItem(session)
             list_view.append(item)

--- a/src/lazy_take_notes/l4_frameworks_and_drivers/workers/audio_worker.py
+++ b/src/lazy_take_notes/l4_frameworks_and_drivers/workers/audio_worker.py
@@ -286,7 +286,7 @@ def run_audio_worker(
                         _zero_warned = True
                         log.warning('Audio signal is all-zero for 5s — source may be dead')
                         post_message(
-                            AudioWorkerStatus(status='warning', error='Audio signal lost — no sound from source')
+                            AudioWorkerStatus(status='warning', error='Audio signal lost: no sound from source')
                         )
                 else:
                     if _zero_warned and _consecutive_zero_chunks > 0:

--- a/tests/l1_entities/test_session_status.py
+++ b/tests/l1_entities/test_session_status.py
@@ -1,0 +1,28 @@
+"""Tests for the SessionStatus entity."""
+
+from __future__ import annotations
+
+from lazy_take_notes.l1_entities.session_status import (
+    DIGESTING,
+    ERROR,
+    LIVE_STATES,
+    RECORDING,
+    STOPPED,
+    SessionStatus,
+)
+
+
+def test_constructs_with_defaults():
+    status = SessionStatus(state=RECORDING, pid=123, started_at='t0', updated_at='t1')
+    assert status.segment_count == 0
+    assert status.digest_count == 0
+    assert not status.error
+
+
+def test_live_states_membership():
+    # Active states imply a process should be running...
+    assert RECORDING in LIVE_STATES
+    assert DIGESTING in LIVE_STATES
+    # ...terminal states do not.
+    assert STOPPED not in LIVE_STATES
+    assert ERROR not in LIVE_STATES

--- a/tests/l3_interface_adapters/gateways/test_coreaudio_tap_source.py
+++ b/tests/l3_interface_adapters/gateways/test_coreaudio_tap_source.py
@@ -59,6 +59,23 @@ class TestCoreAudioTapSource:
         assert result is not None
         np.testing.assert_allclose(result[: len(expected_values)], expected_values, atol=1e-6)
 
+    def test_spawns_in_own_session(self, monkeypatch, tmp_path):
+        # Ctrl-C must not reach the tap subprocess in headless mode, so it runs
+        # in its own session (process group).
+        monkeypatch.setattr(sys, 'platform', 'darwin')
+        fake_binary = tmp_path / 'coreaudio-tap'
+        fake_binary.write_bytes(b'')
+        monkeypatch.setattr(coreaudio_mod, '_BINARY', fake_binary)
+
+        mock_proc = MagicMock()
+        mock_proc.stdout.read.return_value = b''
+        with patch('subprocess.Popen', return_value=mock_proc) as mock_popen:
+            src = CoreAudioTapSource()
+            src.open(16000, 1)
+            src.close()
+
+        assert mock_popen.call_args.kwargs['start_new_session'] is True
+
     def test_read_returns_none_on_timeout(self, monkeypatch, tmp_path):
         monkeypatch.setattr(sys, 'platform', 'darwin')
 

--- a/tests/l3_interface_adapters/gateways/test_session_reader.py
+++ b/tests/l3_interface_adapters/gateways/test_session_reader.py
@@ -1,0 +1,119 @@
+"""Tests for the read-only session reader gateway."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from lazy_take_notes.l3_interface_adapters.gateways.session_reader import (
+    SessionInfo,
+    latest_session,
+    list_sessions,
+    read_notes,
+    read_transcript,
+)
+
+
+def _create_session(
+    base_dir: Path,
+    name: str,
+    *,
+    has_notes: bool = False,
+    transcript: str = 'Hello\nWorld\n',
+    notes_text: str = '# Summary\nKey points.',
+    transcript_name: str = 'transcript.txt',
+    notes_name: str = 'notes.md',
+) -> Path:
+    session_dir = base_dir / name
+    session_dir.mkdir()
+    (session_dir / transcript_name).write_text(transcript, encoding='utf-8')
+    if has_notes:
+        (session_dir / notes_name).write_text(notes_text, encoding='utf-8')
+    return session_dir
+
+
+class TestListSessions:
+    def test_empty_dir(self, tmp_path: Path):
+        assert list_sessions(tmp_path) == []
+
+    def test_nonexistent_dir(self, tmp_path: Path):
+        assert list_sessions(tmp_path / 'nope') == []
+
+    def test_finds_sessions_newest_first(self, tmp_path: Path):
+        _create_session(tmp_path, '2026-02-20_120000')
+        _create_session(tmp_path, '2026-02-21_120000', has_notes=True)
+
+        result = list_sessions(tmp_path)
+
+        assert [s.name for s in result] == ['2026-02-21_120000', '2026-02-20_120000']
+        assert result[0].has_notes is True
+        assert result[1].has_notes is False
+        assert isinstance(result[0], SessionInfo)
+
+    def test_ignores_dirs_without_transcript(self, tmp_path: Path):
+        (tmp_path / 'empty_session').mkdir()
+        _create_session(tmp_path, '2026-02-20_120000')
+
+        assert len(list_sessions(tmp_path)) == 1
+
+    def test_ignores_files(self, tmp_path: Path):
+        (tmp_path / 'not_a_dir.txt').write_text('nope')
+        _create_session(tmp_path, '2026-02-20_120000')
+
+        assert len(list_sessions(tmp_path)) == 1
+
+    def test_recognises_legacy_filenames(self, tmp_path: Path):
+        _create_session(
+            tmp_path,
+            '2026-02-20_120000',
+            has_notes=True,
+            transcript_name='transcript_raw.txt',
+            notes_name='digest.md',
+        )
+
+        result = list_sessions(tmp_path)
+
+        assert len(result) == 1
+        assert result[0].has_notes is True
+
+
+class TestLatestSession:
+    def test_none_when_empty(self, tmp_path: Path):
+        assert latest_session(tmp_path) is None
+
+    def test_returns_newest(self, tmp_path: Path):
+        _create_session(tmp_path, '2026-02-20_120000')
+        _create_session(tmp_path, '2026-02-21_120000')
+
+        latest = latest_session(tmp_path)
+
+        assert latest is not None
+        assert latest.name == '2026-02-21_120000'
+
+
+class TestReadTranscript:
+    def test_returns_text(self, tmp_path: Path):
+        session_dir = _create_session(tmp_path, 's', transcript='line one\n')
+        assert read_transcript(session_dir) == 'line one\n'
+
+    def test_reads_legacy_name(self, tmp_path: Path):
+        session_dir = _create_session(tmp_path, 's', transcript='legacy\n', transcript_name='transcript_raw.txt')
+        assert read_transcript(session_dir) == 'legacy\n'
+
+    def test_none_when_absent(self, tmp_path: Path):
+        empty = tmp_path / 'empty'
+        empty.mkdir()
+        assert read_transcript(empty) is None
+
+
+class TestReadNotes:
+    def test_returns_text(self, tmp_path: Path):
+        session_dir = _create_session(tmp_path, 's', has_notes=True, notes_text='# Notes\n')
+        assert read_notes(session_dir) == '# Notes\n'
+
+    def test_reads_legacy_name(self, tmp_path: Path):
+        session_dir = _create_session(tmp_path, 's', has_notes=True, notes_text='# Legacy\n', notes_name='digest.md')
+        assert read_notes(session_dir) == '# Legacy\n'
+
+    def test_none_when_absent(self, tmp_path: Path):
+        session_dir = _create_session(tmp_path, 's')
+        assert read_notes(session_dir) is None

--- a/tests/l3_interface_adapters/gateways/test_session_status.py
+++ b/tests/l3_interface_adapters/gateways/test_session_status.py
@@ -1,0 +1,85 @@
+"""Tests for the session status gateway (write/read/liveness)."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import cast
+
+from lazy_take_notes.l1_entities.session_status import RECORDING, SessionStatus
+from lazy_take_notes.l3_interface_adapters.gateways.session_status import (
+    STATUS_FILE,
+    is_pid_alive,
+    read_status,
+    write_status,
+)
+
+
+def _status() -> SessionStatus:
+    return SessionStatus(
+        state=RECORDING,
+        pid=4242,
+        started_at='2026-06-06T09:00:00',
+        updated_at='2026-06-06T09:01:00',
+        segment_count=7,
+        digest_count=2,
+    )
+
+
+class TestWriteRead:
+    def test_round_trip(self, tmp_path: Path):
+        write_status(tmp_path, _status())
+
+        result = read_status(tmp_path)
+
+        assert result == _status()
+
+    def test_write_is_atomic_no_leftover_tmp(self, tmp_path: Path):
+        write_status(tmp_path, _status())
+        assert (tmp_path / STATUS_FILE).exists()
+        assert not (tmp_path / (STATUS_FILE + '.tmp')).exists()
+
+    def test_read_missing_returns_none(self, tmp_path: Path):
+        assert read_status(tmp_path) is None
+
+    def test_read_corrupt_returns_none(self, tmp_path: Path):
+        (tmp_path / STATUS_FILE).write_text('{not json', encoding='utf-8')
+        assert read_status(tmp_path) is None
+
+    def test_read_wrong_schema_returns_none(self, tmp_path: Path):
+        (tmp_path / STATUS_FILE).write_text('{"unexpected": 1}', encoding='utf-8')
+        assert read_status(tmp_path) is None
+
+
+class TestPidLiveness:
+    def test_current_process_is_alive(self):
+        assert is_pid_alive(os.getpid()) is True
+
+    def test_zero_and_negative_are_dead(self):
+        assert is_pid_alive(0) is False
+        assert is_pid_alive(-1) is False
+
+    def test_unused_pid_is_dead(self):
+        # Very high PID unlikely to exist on a normal system.
+        assert is_pid_alive(2_000_000_000) is False
+
+    def test_non_int_pid_is_dead(self):
+        # Guards a corrupt status file that stored pid as a wrong type (cast to
+        # satisfy the type checker — the runtime guard is exactly what's tested).
+        assert is_pid_alive(cast(int, '1234')) is False
+        assert is_pid_alive(cast(int, None)) is False
+
+    def test_permission_error_means_alive(self, monkeypatch):
+        def _raise(_pid, _sig):
+            raise PermissionError
+
+        monkeypatch.setattr(os, 'kill', _raise)
+        # A process we can't signal still exists.
+        assert is_pid_alive(12345) is True
+
+    def test_other_oserror_means_dead(self, monkeypatch):
+        def _raise(_pid, _sig):
+            raise OSError
+
+        monkeypatch.setattr(os, 'kill', _raise)
+        assert is_pid_alive(12345) is False

--- a/tests/l3_interface_adapters/gateways/test_subprocess_whisper_transcriber.py
+++ b/tests/l3_interface_adapters/gateways/test_subprocess_whisper_transcriber.py
@@ -220,6 +220,8 @@ class TestSubprocessEntry:
         second_send = conn.send.call_args_list[1][0][0]
         assert second_send['status'] == 'ok'
         conn.close.assert_called_once()
+        # Detaches from the terminal's process group so Ctrl-C can't kill it mid-transcribe.
+        mock_os.setsid.assert_called_once()
 
     def test_init_failure_sends_error_and_closes(self):
         import lazy_take_notes.l3_interface_adapters.gateways.subprocess_whisper_transcriber as sp_mod

--- a/tests/l4_frameworks_and_drivers/pickers/test_session_picker.py
+++ b/tests/l4_frameworks_and_drivers/pickers/test_session_picker.py
@@ -8,7 +8,6 @@ import pytest
 
 from lazy_take_notes.l4_frameworks_and_drivers.pickers.session_picker import (
     SessionPicker,
-    discover_sessions,
 )
 
 
@@ -27,40 +26,6 @@ def _create_session(
     if has_digest:
         (session_dir / 'notes.md').write_text(digest_text, encoding='utf-8')
     return session_dir
-
-
-class TestDiscoverSessions:
-    def test_empty_dir(self, tmp_path: Path):
-        assert discover_sessions(tmp_path) == []
-
-    def test_nonexistent_dir(self, tmp_path: Path):
-        assert discover_sessions(tmp_path / 'nope') == []
-
-    def test_finds_sessions(self, tmp_path: Path):
-        _create_session(tmp_path, '2026-02-20_120000')
-        _create_session(tmp_path, '2026-02-21_120000', has_digest=True)
-
-        result = discover_sessions(tmp_path)
-        assert len(result) == 2
-        # Sorted newest-first
-        assert result[0]['name'] == '2026-02-21_120000'
-        assert result[0]['has_digest'] is True
-        assert result[1]['name'] == '2026-02-20_120000'
-        assert result[1]['has_digest'] is False
-
-    def test_ignores_dirs_without_transcript(self, tmp_path: Path):
-        (tmp_path / 'empty_session').mkdir()
-        _create_session(tmp_path, '2026-02-20_120000')
-
-        result = discover_sessions(tmp_path)
-        assert len(result) == 1
-
-    def test_ignores_files(self, tmp_path: Path):
-        (tmp_path / 'not_a_dir.txt').write_text('nope')
-        _create_session(tmp_path, '2026-02-20_120000')
-
-        result = discover_sessions(tmp_path)
-        assert len(result) == 1
 
 
 class TestSessionPicker:

--- a/tests/l4_frameworks_and_drivers/test_cli.py
+++ b/tests/l4_frameworks_and_drivers/test_cli.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+import os
 import re
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -40,6 +42,15 @@ _WELCOME_PICKER = 'lazy_take_notes.l4_frameworks_and_drivers.pickers.welcome_pic
 
 _CLI = 'lazy_take_notes.l4_frameworks_and_drivers.cli'
 _CLI_HELPERS = 'lazy_take_notes.l4_frameworks_and_drivers.cli_helpers'
+
+
+@pytest.fixture(autouse=True)
+def _no_caffeinate(monkeypatch):
+    """Never spawn the real `caffeinate` inhibitor during CLI tests."""
+    monkeypatch.setattr(
+        'lazy_take_notes.l4_frameworks_and_drivers.keep_awake.inhibit_sleep',
+        lambda: None,
+    )
 
 
 class TestMakeSessionDir:
@@ -592,6 +603,411 @@ class TestViewSubcommand:
             runner.invoke(cli, ['view'])
 
         mock_app_cls.return_value.run.assert_called_once()
+
+
+def _make_session(base_dir: Path, name: str, *, notes: str | None = None, transcript: str = 'hello\n') -> Path:
+    session_dir = base_dir / name
+    session_dir.mkdir(parents=True)
+    (session_dir / 'transcript.txt').write_text(transcript, encoding='utf-8')
+    if notes is not None:
+        (session_dir / 'notes.md').write_text(notes, encoding='utf-8')
+    return session_dir
+
+
+def _invoke_read(args: list[str], base_dir: Path):
+    runner = CliRunner()
+    with (
+        patch(_YAML_CFG) as mock_config_cls,
+        patch(_YAML_TPL),
+        patch(_BUILD) as mock_build,
+        patch(_INFRA),
+    ):
+        mock_config_cls.return_value.load.return_value = {}
+        mock_build.return_value = MagicMock(output=MagicMock(directory=str(base_dir)))
+        return runner.invoke(cli, args)
+
+
+class TestReadCommands:
+    def test_ls_empty(self, tmp_path: Path):
+        result = _invoke_read(['ls'], tmp_path)
+        assert result.exit_code == 0
+        assert 'No sessions found.' in result.output
+
+    def test_ls_lists_newest_first(self, tmp_path: Path):
+        _make_session(tmp_path, '2026-02-20_120000')
+        _make_session(tmp_path, '2026-02-21_120000', notes='# Notes')
+
+        result = _invoke_read(['ls'], tmp_path)
+
+        assert result.exit_code == 0
+        lines = result.output.strip().splitlines()
+        assert '2026-02-21_120000' in lines[0]
+        assert 'notes' in lines[0]
+        assert '2026-02-20_120000' in lines[1]
+
+    def test_ls_json(self, tmp_path: Path):
+        _make_session(tmp_path, '2026-02-21_120000', notes='# Notes')
+
+        result = _invoke_read(['ls', '--json'], tmp_path)
+
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert payload[0]['name'] == '2026-02-21_120000'
+        assert payload[0]['has_notes'] is True
+
+    def test_ls_caps_at_twenty_by_default(self, tmp_path: Path):
+        for day in range(1, 23):  # 22 sessions
+            _make_session(tmp_path, f'2026-06-{day:02d}_120000')
+
+        result = _invoke_read(['ls'], tmp_path)
+
+        assert result.exit_code == 0
+        # Newest 20 shown (days 22..03); the two oldest hidden.
+        assert '2026-06-22_120000' in result.output
+        assert '2026-06-01_120000' not in result.output
+        assert '2026-06-02_120000' not in result.output
+        assert '... 2 more' in result.stderr
+
+    def test_ls_all_shows_everything(self, tmp_path: Path):
+        for day in range(1, 23):
+            _make_session(tmp_path, f'2026-06-{day:02d}_120000')
+
+        result = _invoke_read(['ls', '--all'], tmp_path)
+
+        assert result.exit_code == 0
+        assert '2026-06-01_120000' in result.output
+        assert 'more' not in result.stderr
+
+    def test_ls_json_is_unlimited(self, tmp_path: Path):
+        for day in range(1, 23):
+            _make_session(tmp_path, f'2026-06-{day:02d}_120000')
+
+        result = _invoke_read(['ls', '--json'], tmp_path)
+
+        assert result.exit_code == 0
+        assert len(json.loads(result.output)) == 22
+
+    def test_transcript_defaults_to_newest(self, tmp_path: Path):
+        _make_session(tmp_path, '2026-02-20_120000', transcript='old\n')
+        _make_session(tmp_path, '2026-02-21_120000', transcript='newest transcript\n')
+
+        result = _invoke_read(['transcript'], tmp_path)
+
+        assert result.exit_code == 0
+        assert result.output == 'newest transcript\n'
+
+    def test_transcript_by_exact_name(self, tmp_path: Path):
+        _make_session(tmp_path, '2026-02-20_120000_a', transcript='AAA\n')
+        _make_session(tmp_path, '2026-02-21_120000_b', transcript='BBB\n')
+
+        result = _invoke_read(['transcript', '2026-02-20_120000_a'], tmp_path)
+
+        assert result.exit_code == 0
+        assert result.output == 'AAA\n'
+
+    def test_transcript_by_substring(self, tmp_path: Path):
+        _make_session(tmp_path, '2026-02-20_120000_standup', transcript='standup notes\n')
+        _make_session(tmp_path, '2026-02-21_120000_retro', transcript='retro notes\n')
+
+        result = _invoke_read(['transcript', 'standup'], tmp_path)
+
+        assert result.exit_code == 0
+        assert result.output == 'standup notes\n'
+
+    def test_transcript_no_sessions_errors(self, tmp_path: Path):
+        result = _invoke_read(['transcript'], tmp_path)
+        assert result.exit_code != 0
+        assert 'No sessions found.' in result.output
+
+    def test_transcript_ambiguous_errors(self, tmp_path: Path):
+        _make_session(tmp_path, '2026-02-20_120000_sync')
+        _make_session(tmp_path, '2026-02-21_120000_sync')
+
+        result = _invoke_read(['transcript', 'sync'], tmp_path)
+
+        assert result.exit_code != 0
+        assert 'multiple sessions' in result.output
+
+    def test_transcript_no_match_errors(self, tmp_path: Path):
+        _make_session(tmp_path, '2026-02-20_120000')
+
+        result = _invoke_read(['transcript', 'nope'], tmp_path)
+
+        assert result.exit_code != 0
+        assert 'No session matching' in result.output
+
+    def test_notes_defaults_to_newest(self, tmp_path: Path):
+        _make_session(tmp_path, '2026-02-21_120000', notes='# Summary\nDone.')
+
+        result = _invoke_read(['notes'], tmp_path)
+
+        assert result.exit_code == 0
+        assert result.output == '# Summary\nDone.'
+
+    def test_notes_missing_errors(self, tmp_path: Path):
+        _make_session(tmp_path, '2026-02-21_120000')
+
+        result = _invoke_read(['notes'], tmp_path)
+
+        assert result.exit_code != 0
+        assert 'has no notes' in result.output
+
+
+_HEADLESS = 'lazy_take_notes.l4_frameworks_and_drivers.headless'
+
+
+class TestHeadlessFlag:
+    def test_record_headless_requires_language(self, tmp_path: Path):
+        runner = CliRunner()
+        result = runner.invoke(cli, ['record', '--headless'])
+        assert result.exit_code != 0
+        assert 'requires --language' in result.output
+
+    def test_record_headless_custom_template(self, tmp_path: Path):
+        runner = CliRunner()
+        with patch(f'{_HEADLESS}.run_record_headless') as mock_run:
+            result = runner.invoke(cli, ['record', '--headless', '--template', 'sprint_retro_en'])
+        assert result.exit_code == 0
+        assert mock_run.call_args.kwargs['template_name'] == 'sprint_retro_en'
+
+    def test_record_headless_language(self, tmp_path: Path):
+        runner = CliRunner()
+        with patch(f'{_HEADLESS}.run_record_headless') as mock_run:
+            result = runner.invoke(cli, ['record', '--headless', '--language', 'zh-TW'])
+        assert result.exit_code == 0
+        assert mock_run.call_args.kwargs['language'] == 'zh-TW'
+
+    def test_record_headless_mute_mic(self, tmp_path: Path):
+        runner = CliRunner()
+        with patch(f'{_HEADLESS}.run_record_headless') as mock_run:
+            result = runner.invoke(cli, ['record', '--headless', '--language', 'en', '--mute-mic'])
+        assert result.exit_code == 0
+        assert mock_run.call_args.kwargs['mute_mic'] is True
+
+    def test_template_and_language_are_mutually_exclusive(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ['record', '--template', 'default_en', '--language', 'en'])
+        assert result.exit_code != 0
+        assert 'not both' in result.output
+
+    def test_record_mute_mic_tui(self, tmp_path: Path):
+        runner = CliRunner()
+        mock_picker = MagicMock()
+        mock_picker.run.return_value = ('default_en', MagicMock())
+        mock_template_loader = MagicMock()
+        mock_template_loader.load.return_value = MagicMock(
+            metadata=MagicMock(locale='en-US'), quick_actions=[], recognition_hints=[]
+        )
+        with (
+            patch(_YAML_CFG) as mock_config_cls,
+            patch(_YAML_TPL, return_value=mock_template_loader),
+            patch(_BUILD) as mock_build,
+            patch(_INFRA),
+            patch(_PICKER, return_value=mock_picker),
+            patch(f'{_CLI_HELPERS}.preflight_llm', return_value=([], [])),
+            patch(f'{_CLI_HELPERS}.preflight_microphone'),
+            patch('lazy_take_notes.l4_frameworks_and_drivers.apps.record.RecordApp'),
+            patch('lazy_take_notes.l4_frameworks_and_drivers.container.DependencyContainer') as mock_container_cls,
+        ):
+            mock_config_cls.return_value.load.return_value = {}
+            mock_build.return_value = MagicMock(output=MagicMock(directory=str(tmp_path)))
+            result = runner.invoke(cli, ['record', '--mute-mic'])
+
+        assert result.exit_code == 0
+        assert mock_container_cls.return_value.audio_source.mic_muted is True
+
+    def test_transcribe_headless_routes_to_runner(self, tmp_path: Path):
+        runner = CliRunner()
+        audio = tmp_path / 'a.wav'
+        audio.touch()
+        with patch(f'{_HEADLESS}.run_transcribe_headless') as mock_run:
+            result = runner.invoke(cli, ['transcribe', '--headless', str(audio), '--language', 'en'])
+        assert result.exit_code == 0
+        assert mock_run.call_args.kwargs['audio_path'] == audio
+        assert mock_run.call_args.kwargs['language'] == 'en'
+
+    def test_transcribe_headless_without_file_errors(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ['transcribe', '--headless'])
+        assert result.exit_code != 0
+        assert 'requires an audio file' in result.output
+
+    def test_transcribe_headless_requires_language(self, tmp_path: Path):
+        runner = CliRunner()
+        audio = tmp_path / 'a.wav'
+        audio.touch()
+        result = runner.invoke(cli, ['transcribe', '--headless', str(audio)])
+        assert result.exit_code != 0
+        assert 'requires --language' in result.output
+
+
+def _write_status(
+    base_dir: Path,
+    name: str,
+    *,
+    state: str = 'recording',
+    pid: int | None = None,
+    segment_count: int = 3,
+    digest_count: int = 1,
+    error: str = '',
+) -> Path:
+    from lazy_take_notes.l1_entities.session_status import SessionStatus
+    from lazy_take_notes.l3_interface_adapters.gateways.session_status import write_status
+
+    session_dir = base_dir / name
+    session_dir.mkdir(parents=True)
+    write_status(
+        session_dir,
+        SessionStatus(
+            state=state,
+            pid=os.getpid() if pid is None else pid,
+            started_at='2026-06-06T09:00:00',
+            updated_at='2026-06-06T09:01:00',
+            segment_count=segment_count,
+            digest_count=digest_count,
+            error=error,
+        ),
+    )
+    return session_dir
+
+
+class TestStatusCommand:
+    def test_shows_newest_session(self, tmp_path: Path):
+        _write_status(tmp_path, '2026-06-01_090000', segment_count=1)
+        _write_status(tmp_path, '2026-06-05_140000', segment_count=9)
+
+        result = _invoke_read(['status'], tmp_path)
+
+        assert result.exit_code == 0
+        assert '2026-06-05_140000' in result.output
+        assert 'segments: 9' in result.output
+        assert f'pid:      {os.getpid()}' in result.output
+
+    def test_crashed_session_flagged(self, tmp_path: Path):
+        _write_status(tmp_path, '2026-06-05_140000', state='recording', pid=2_000_000_000)
+
+        result = _invoke_read(['status'], tmp_path)
+
+        assert result.exit_code == 0
+        assert 'crashed' in result.output
+
+    def test_no_session_errors(self, tmp_path: Path):
+        result = _invoke_read(['status'], tmp_path)
+        assert result.exit_code != 0
+        assert 'No headless session found.' in result.output
+
+    def test_status_by_name(self, tmp_path: Path):
+        _write_status(tmp_path, '2026-06-01_090000', segment_count=1)
+        _write_status(tmp_path, '2026-06-05_140000', segment_count=9)
+
+        result = _invoke_read(['status', '2026-06-01_090000'], tmp_path)
+
+        assert result.exit_code == 0
+        assert 'segments: 1' in result.output
+
+    def test_status_corrupt_file_errors(self, tmp_path: Path):
+        from lazy_take_notes.l3_interface_adapters.gateways.session_status import STATUS_FILE
+
+        session_dir = tmp_path / '2026-06-05_140000'
+        session_dir.mkdir()
+        (session_dir / STATUS_FILE).write_text('{not json', encoding='utf-8')
+
+        result = _invoke_read(['status'], tmp_path)
+
+        assert result.exit_code != 0
+        assert 'missing or unreadable' in result.output
+
+    def test_error_state_shown(self, tmp_path: Path):
+        _write_status(tmp_path, '2026-06-05_140000', state='error', error='boom')
+
+        result = _invoke_read(['status'], tmp_path)
+
+        assert result.exit_code == 0
+        assert 'error:    boom' in result.output
+
+
+class TestTemplateSelection:
+    def _loader(self):
+        from lazy_take_notes.l3_interface_adapters.gateways.yaml_template_loader import YamlTemplateLoader
+
+        return YamlTemplateLoader()
+
+    def test_resolve_language_match(self):
+        from lazy_take_notes.l4_frameworks_and_drivers.cli_helpers import resolve_language
+
+        template = resolve_language(self._loader(), 'zh-TW')
+        assert template.metadata.key == 'default_zh_tw'
+        assert template.metadata.locale == 'zh-TW'
+
+    def test_resolve_language_is_case_insensitive(self):
+        from lazy_take_notes.l4_frameworks_and_drivers.cli_helpers import resolve_language
+
+        assert resolve_language(self._loader(), 'EN').metadata.key == 'default_en'
+
+    def test_resolve_language_unsupported_stops(self):
+        from lazy_take_notes.l4_frameworks_and_drivers.cli_helpers import resolve_language
+
+        with pytest.raises(click.ClickException, match='Unsupported language'):
+            resolve_language(self._loader(), 'xx')
+
+    def test_resolve_language_primary_subtag_fallback(self):
+        from lazy_take_notes.l4_frameworks_and_drivers.cli_helpers import resolve_language
+
+        # en-US has no exact template; falls back to the unambiguous primary subtag 'en'.
+        assert resolve_language(self._loader(), 'en-US').metadata.key == 'default_en'
+
+    def test_resolve_language_ambiguous_subtag_stops(self):
+        from lazy_take_notes.l4_frameworks_and_drivers.cli_helpers import resolve_language
+
+        # 'zh' matches both zh-TW and zh-min-nan -> ambiguous -> fail loud.
+        with pytest.raises(click.ClickException, match='Unsupported language'):
+            resolve_language(self._loader(), 'zh')
+
+    def test_load_template_key_valid(self):
+        from lazy_take_notes.l4_frameworks_and_drivers.cli_helpers import load_template_key
+
+        assert load_template_key(self._loader(), 'sprint_retro_en').metadata.key == 'sprint_retro_en'
+
+    def test_load_template_key_unknown_stops(self):
+        from lazy_take_notes.l4_frameworks_and_drivers.cli_helpers import load_template_key
+
+        with pytest.raises(click.ClickException, match='Unknown template'):
+            load_template_key(self._loader(), 'no_such_template')
+
+    def test_select_template_prefers_language(self):
+        from lazy_take_notes.l4_frameworks_and_drivers.cli_helpers import select_template
+
+        template = select_template(self._loader(), template_name=None, language='en', show_builtins=True)
+        assert template.metadata.key == 'default_en'
+
+    def test_select_template_by_key(self):
+        from lazy_take_notes.l4_frameworks_and_drivers.cli_helpers import select_template
+
+        template = select_template(self._loader(), template_name='lecture_notes_en', language=None, show_builtins=True)
+        assert template.metadata.key == 'lecture_notes_en'
+
+    def test_select_template_falls_back_to_picker(self, monkeypatch):
+        from lazy_take_notes.l4_frameworks_and_drivers import cli_helpers as ch
+
+        sentinel = object()
+        monkeypatch.setattr(ch, 'pick_template', lambda loader, show_builtins: sentinel)
+        result = ch.select_template(self._loader(), template_name=None, language=None, show_builtins=True)
+        assert result is sentinel
+
+    def test_set_mic_muted_on_supporting_source(self):
+        from lazy_take_notes.l4_frameworks_and_drivers.cli_helpers import set_mic_muted
+
+        class _Src:
+            mic_muted = False
+
+        src = _Src()
+        set_mic_muted(src, True)
+        assert src.mic_muted is True
+
+    def test_set_mic_muted_noop_without_attr(self):
+        from lazy_take_notes.l4_frameworks_and_drivers.cli_helpers import set_mic_muted
+
+        set_mic_muted(object(), True)  # must not raise
 
 
 class TestLoadPlugins:

--- a/tests/l4_frameworks_and_drivers/test_headless.py
+++ b/tests/l4_frameworks_and_drivers/test_headless.py
@@ -1,0 +1,613 @@
+"""Tests for the headless session runner.
+
+Drives HeadlessSession with a fake worker launcher (no real audio/whisper) and
+a real SessionController wired to FakeLLMClient + FakePersistence.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import cast
+from unittest.mock import MagicMock
+
+import click
+import pytest
+
+from lazy_take_notes.l1_entities import session_status as st
+from lazy_take_notes.l1_entities.transcript import TranscriptSegment
+from lazy_take_notes.l3_interface_adapters.controllers.session_controller import SessionController
+from lazy_take_notes.l3_interface_adapters.gateways.session_status import read_status
+from lazy_take_notes.l4_frameworks_and_drivers.config import build_app_config
+from lazy_take_notes.l4_frameworks_and_drivers.headless import (
+    HeadlessSession,
+    _banner_lines,  # noqa: PLC2701 -- testing module-private formatter
+    _clock,  # noqa: PLC2701 -- testing module-private formatter
+    _heartbeat_line,  # noqa: PLC2701 -- testing module-private formatter
+    _select_headless_template,  # noqa: PLC2701 -- testing module-private selector
+    _shared_worker_kwargs,  # noqa: PLC2701 -- testing module-private helper
+    _summary_lines,  # noqa: PLC2701 -- testing module-private formatter
+    _warn_missing_models,  # noqa: PLC2701 -- testing module-private helper
+)
+from lazy_take_notes.l4_frameworks_and_drivers.messages import (
+    AudioWorkerStatus,
+    ModelDownloadProgress,
+    TranscriptChunk,
+)
+
+
+@pytest.fixture(autouse=True)
+def _no_caffeinate(monkeypatch):
+    """Never spawn the real `caffeinate` inhibitor during tests."""
+    monkeypatch.setattr(
+        'lazy_take_notes.l4_frameworks_and_drivers.keep_awake.inhibit_sleep',
+        lambda: None,
+    )
+
+
+def _seg(text: str) -> TranscriptSegment:
+    return TranscriptSegment(text=text, wall_start=0.0, wall_end=1.0)
+
+
+def _read(tmp_path: Path) -> st.SessionStatus:
+    status = read_status(tmp_path)
+    assert status is not None
+    return status
+
+
+def _controller(template, persistence, fake_llm, *, eager_digest: bool = False) -> SessionController:
+    raw = {'digest': {'min_lines': 1, 'min_interval': 0.0, 'max_lines': 1}} if eager_digest else {}
+    config = build_app_config(raw)
+    return SessionController(config=config, template=template, llm_client=fake_llm, persistence=persistence)
+
+
+class TestHeadlessSession:
+    @pytest.mark.asyncio
+    async def test_runs_to_stopped_and_persists(self, tmp_path: Path, default_template, fake_persistence, fake_llm):
+        controller = _controller(default_template, fake_persistence, fake_llm)
+
+        def launcher(post_message, _is_cancelled):
+            post_message(AudioWorkerStatus(status='model_ready'))
+            post_message(TranscriptChunk(segments=[_seg('hello'), _seg('world')]))
+            post_message(AudioWorkerStatus(status='stopped'))
+
+        session = HeadlessSession(controller, tmp_path, launcher)
+        await session.run()
+
+        status = read_status(tmp_path)
+        assert status is not None
+        assert status.state == st.STOPPED
+        assert status.segment_count == 2
+        # Transcript was persisted, and a final digest ran on completion.
+        assert fake_persistence.transcript_calls
+        assert fake_persistence.digest_calls
+
+    @pytest.mark.asyncio
+    async def test_worker_error_sets_error_state(self, tmp_path: Path, default_template, fake_persistence, fake_llm):
+        controller = _controller(default_template, fake_persistence, fake_llm)
+
+        def launcher(post_message, _is_cancelled):
+            post_message(AudioWorkerStatus(status='error', error='device gone'))
+
+        session = HeadlessSession(controller, tmp_path, launcher)
+        await session.run()
+
+        status = _read(tmp_path)
+        assert status.state == st.ERROR
+        assert status.error == 'device gone'
+        # No final digest after an error.
+        assert not fake_persistence.digest_calls
+
+    @pytest.mark.asyncio
+    async def test_incremental_digest_triggers_on_chunk(
+        self, tmp_path: Path, default_template, fake_persistence, fake_llm
+    ):
+        controller = _controller(default_template, fake_persistence, fake_llm, eager_digest=True)
+
+        def launcher(post_message, _is_cancelled):
+            post_message(TranscriptChunk(segments=[_seg('trigger me')]))
+            post_message(AudioWorkerStatus(status='stopped'))
+
+        session = HeadlessSession(controller, tmp_path, launcher)
+        await session.run()
+
+        # One incremental digest (from the chunk) + one final digest.
+        assert len(fake_persistence.digest_calls) >= 2
+        assert _read(tmp_path).state == st.STOPPED
+
+    @pytest.mark.asyncio
+    async def test_progress_messages_update_state(self, tmp_path: Path, default_template, fake_persistence, fake_llm):
+        controller = _controller(default_template, fake_persistence, fake_llm)
+
+        def launcher(post_message, _is_cancelled):
+            post_message(AudioWorkerStatus(status='loading_model'))
+            post_message(ModelDownloadProgress(percent=50, model_name='whatever'))
+            post_message(AudioWorkerStatus(status='recording'))
+            post_message(AudioWorkerStatus(status='stopped'))
+
+        session = HeadlessSession(controller, tmp_path, launcher)
+        await session.run()
+
+        # No transcript, no digest content -> ends stopped without a digest.
+        assert _read(tmp_path).state == st.STOPPED
+        assert not fake_persistence.digest_calls
+
+    def test_request_stop_sets_cancel_and_hints_once(
+        self, tmp_path: Path, default_template, fake_persistence, fake_llm
+    ):
+        controller = _controller(default_template, fake_persistence, fake_llm)
+        reported: list[str] = []
+        session = HeadlessSession(controller, tmp_path, lambda *_: None, report=reported.append)
+
+        session.request_stop()
+        session.request_stop()  # mashing Ctrl-C must not repeat the hint
+
+        assert session._cancel.is_set()  # noqa: SLF001 -- asserting internal stop flag
+        assert sum('stopping' in line for line in reported) == 1
+
+    def test_toggle_mic_flips_and_reports(self, tmp_path: Path, default_template, fake_persistence, fake_llm):
+        class _Src:
+            mic_muted = False
+
+        controller = _controller(default_template, fake_persistence, fake_llm)
+        src = _Src()
+        reported: list[str] = []
+        session = HeadlessSession(controller, tmp_path, lambda *_: None, report=reported.append, audio_source=src)
+
+        session._toggle_mic()  # noqa: SLF001 -- exercising the SIGUSR1 handler
+        assert src.mic_muted is True
+        assert any('muted' in line for line in reported)
+
+        session._toggle_mic()  # noqa: SLF001 -- toggle back
+        assert src.mic_muted is False
+        assert any('unmuted' in line for line in reported)
+
+    @pytest.mark.asyncio
+    async def test_run_with_audio_source_installs_mic_toggle(
+        self, tmp_path: Path, default_template, fake_persistence, fake_llm
+    ):
+        class _Src:
+            mic_muted = False
+
+        controller = _controller(default_template, fake_persistence, fake_llm)
+
+        def launcher(post_message, _is_cancelled):
+            post_message(AudioWorkerStatus(status='stopped'))
+
+        session = HeadlessSession(controller, tmp_path, launcher, audio_source=_Src())
+        await session.run()  # exercises _install_mic_toggle with a source present
+
+        assert _read(tmp_path).state == st.STOPPED
+
+
+class TestHeadlessEntryPoints:
+    def _ctx(self):
+        ctx = MagicMock()
+        ctx.obj = {'config_path': None, 'output_dir': None}
+        return ctx
+
+    def _patch_common(self, monkeypatch, tmp_path, template):
+        from lazy_take_notes.l4_frameworks_and_drivers import headless as hl
+
+        config = build_app_config({'output': {'directory': str(tmp_path)}})
+        loader = MagicMock()
+        loader.load.return_value = template
+        monkeypatch.setattr(hl, 'load_config', lambda *a, **k: (config, MagicMock(), loader))
+        monkeypatch.setattr(hl, 'preflight_llm', lambda *a, **k: ([], []))
+        monkeypatch.setattr(hl, '_build_container', lambda *a, **k: MagicMock())
+        captured: dict = {}
+        monkeypatch.setattr(hl, '_run', lambda out_dir, cfg, session: captured.update(out_dir=out_dir, session=session))
+        return hl, captured
+
+    def test_run_record_headless_wires_session(self, tmp_path, default_template, monkeypatch):
+        hl, captured = self._patch_common(monkeypatch, tmp_path, default_template)
+
+        hl.run_record_headless(self._ctx(), template_name='default_en', label='demo')
+
+        assert captured['out_dir'].exists()
+        assert isinstance(captured['session'], hl.HeadlessSession)
+
+    def test_run_record_headless_mute_mic(self, tmp_path, default_template, monkeypatch):
+        from unittest.mock import MagicMock as _MagicMock
+
+        hl, _ = self._patch_common(monkeypatch, tmp_path, default_template)
+        container = _MagicMock()
+        monkeypatch.setattr(hl, '_build_container', lambda *a, **k: container)
+
+        hl.run_record_headless(self._ctx(), template_name='default_en', mute_mic=True)
+
+        assert container.audio_source.mic_muted is True
+
+    def test_run_transcribe_headless_wires_session(self, tmp_path, default_template, monkeypatch):
+        hl, captured = self._patch_common(monkeypatch, tmp_path, default_template)
+        audio = tmp_path / 'in.wav'
+        audio.touch()
+
+        hl.run_transcribe_headless(self._ctx(), audio_path=audio, template_name='default_en')
+
+        assert captured['out_dir'].exists()
+        assert isinstance(captured['session'], hl.HeadlessSession)
+
+    def test_unknown_template_raises_click_exception(self, monkeypatch):
+        from lazy_take_notes.l4_frameworks_and_drivers import headless as hl
+
+        loader = MagicMock()
+        loader.load.side_effect = FileNotFoundError('nope')
+        loader.list_templates.return_value = [MagicMock(key='default_en')]
+        monkeypatch.setattr(hl, 'load_config', lambda *a, **k: (build_app_config({}), MagicMock(), loader))
+
+        with pytest.raises(click.ClickException, match='Unknown template'):
+            hl.run_record_headless(self._ctx(), template_name='bogus')
+
+
+class TestHeadlessHelpers:
+    def test_build_container_constructs(self, default_template, monkeypatch):
+        from lazy_take_notes.l4_frameworks_and_drivers import headless as hl
+
+        sentinel = object()
+        monkeypatch.setattr(
+            'lazy_take_notes.l4_frameworks_and_drivers.container.DependencyContainer',
+            lambda *a, **k: sentinel,
+        )
+
+        result = hl._build_container(build_app_config({}), default_template, Path('/tmp/x'), MagicMock())  # noqa: SLF001 -- testing module helper
+
+        assert result is sentinel
+
+    def test_run_launches_session(self, tmp_path: Path, monkeypatch):
+        from lazy_take_notes.l4_frameworks_and_drivers import headless as hl
+
+        monkeypatch.setattr(
+            'lazy_take_notes.l4_frameworks_and_drivers.logging_setup.setup_file_logging',
+            lambda *a, **k: None,
+        )
+        ran: dict = {}
+
+        class _FakeSession:
+            status = st.SessionStatus(
+                state=st.STOPPED, pid=1, started_at='2026-06-06T09:00:00', updated_at='2026-06-06T09:00:30'
+            )
+
+            async def run(self):
+                ran['ok'] = True
+
+        hl._run(tmp_path, build_app_config({}), cast(hl.HeadlessSession, _FakeSession()))  # noqa: SLF001 -- testing module helper
+
+        assert ran['ok'] is True
+
+
+class TestHeadlessReporting:
+    @pytest.mark.asyncio
+    async def test_milestones_reported(self, tmp_path: Path, default_template, fake_persistence, fake_llm):
+        from lazy_take_notes.l4_frameworks_and_drivers.messages import ModelDownloadProgress
+
+        controller = _controller(default_template, fake_persistence, fake_llm)
+        reported: list[str] = []
+
+        def launcher(post_message, _is_cancelled):
+            post_message(AudioWorkerStatus(status='loading_model'))
+            post_message(ModelDownloadProgress(percent=10, model_name='ggml'))
+            post_message(ModelDownloadProgress(percent=15, model_name='ggml'))  # same bucket -> not re-reported
+            post_message(AudioWorkerStatus(status='recording'))
+            post_message(AudioWorkerStatus(status='stopped'))
+
+        session = HeadlessSession(controller, tmp_path, launcher, report=reported.append)
+        await session.run()
+
+        assert '… loading model' in reported
+        assert '✓ model ready, recording' in reported
+        assert sum('downloading' in line for line in reported) == 1  # throttled to one per 20% bucket
+
+    @pytest.mark.asyncio
+    async def test_transcription_error_does_not_end_session(
+        self, tmp_path: Path, default_template, fake_persistence, fake_llm
+    ):
+        # A recoverable per-chunk error after recording started must NOT end the session.
+        controller = _controller(default_template, fake_persistence, fake_llm)
+        reported: list[str] = []
+
+        def launcher(post_message, _is_cancelled):
+            post_message(AudioWorkerStatus(status='recording'))  # marks started
+            post_message(AudioWorkerStatus(status='error', error='chunk failed'))  # recoverable
+            post_message(TranscriptChunk(segments=[_seg('still recording')]))
+            post_message(AudioWorkerStatus(status='stopped'))
+
+        session = HeadlessSession(controller, tmp_path, launcher, report=reported.append)
+        await session.run()
+
+        assert any('transcription error (continuing)' in line for line in reported)
+        assert _read(tmp_path).state == st.STOPPED  # not ERROR
+        assert len(controller.all_segments) == 1  # kept processing after the error
+
+    @pytest.mark.asyncio
+    async def test_pump_times_out_after_cancel(
+        self, tmp_path: Path, default_template, fake_persistence, fake_llm, monkeypatch
+    ):
+        import lazy_take_notes.l4_frameworks_and_drivers.headless as hl
+
+        monkeypatch.setattr(hl, 'STOP_GRACE', 0.01)
+        controller = _controller(default_template, fake_persistence, fake_llm)
+        reported: list[str] = []
+
+        def launcher(post_message, _is_cancelled):
+            pass  # wedged worker: never posts 'stopped'
+
+        session = HeadlessSession(controller, tmp_path, launcher, report=reported.append)
+        session.request_stop()  # cancel before the pump starts
+        await session.run()
+
+        assert any('did not stop in time' in line for line in reported)
+        assert _read(tmp_path).state == st.STOPPED
+
+    @pytest.mark.asyncio
+    async def test_run_records_error_on_exception(
+        self, tmp_path: Path, default_template, fake_persistence, fake_llm, monkeypatch
+    ):
+        controller = _controller(default_template, fake_persistence, fake_llm)
+
+        def boom(_segments):
+            raise RuntimeError('disk full')
+
+        monkeypatch.setattr(controller, 'on_transcript_segments', boom)  # force _pump to raise
+
+        def launcher(post_message, _is_cancelled):
+            post_message(TranscriptChunk(segments=[_seg('x')]))
+            post_message(AudioWorkerStatus(status='stopped'))
+
+        session = HeadlessSession(controller, tmp_path, launcher)
+        with pytest.raises(RuntimeError, match='disk full'):
+            await session.run()
+
+        assert _read(tmp_path).state == st.ERROR
+
+    @pytest.mark.asyncio
+    async def test_no_sound_warning_reported(self, tmp_path: Path, default_template, fake_persistence, fake_llm):
+        controller = _controller(default_template, fake_persistence, fake_llm)
+        reported: list[str] = []
+
+        def launcher(post_message, _is_cancelled):
+            post_message(AudioWorkerStatus(status='warning', error='Audio signal lost: no sound from source'))
+            post_message(AudioWorkerStatus(status='stopped'))
+
+        session = HeadlessSession(controller, tmp_path, launcher, report=reported.append)
+        await session.run()
+
+        assert any('⚠' in line and 'no sound' in line for line in reported)
+
+    @pytest.mark.asyncio
+    async def test_error_reported(self, tmp_path: Path, default_template, fake_persistence, fake_llm):
+        controller = _controller(default_template, fake_persistence, fake_llm)
+        reported: list[str] = []
+
+        def launcher(post_message, _is_cancelled):
+            post_message(AudioWorkerStatus(status='error', error='boom'))
+
+        session = HeadlessSession(controller, tmp_path, launcher, report=reported.append)
+        await session.run()
+
+        assert any('✗ error: boom' in line for line in reported)
+
+    @pytest.mark.asyncio
+    async def test_error_during_shutdown_is_graceful(
+        self, tmp_path: Path, default_template, fake_persistence, fake_llm
+    ):
+        # A teardown error after the user asked to stop must not flip the session to 'error'.
+        controller = _controller(default_template, fake_persistence, fake_llm)
+        reported: list[str] = []
+
+        def launcher(post_message, _is_cancelled):
+            post_message(AudioWorkerStatus(status='error', error='[Errno 32] Broken pipe'))
+
+        session = HeadlessSession(controller, tmp_path, launcher, report=reported.append)
+        session.request_stop()  # user already pressed Ctrl-C
+        await session.run()
+
+        assert _read(tmp_path).state == st.STOPPED
+        assert not any('✗ error' in line for line in reported)
+
+    @pytest.mark.asyncio
+    async def test_digest_failure_reported(self, tmp_path: Path, default_template, fake_persistence, fake_llm):
+        fake_llm.set_response('')  # empty response -> digest use case returns an error
+        controller = _controller(default_template, fake_persistence, fake_llm, eager_digest=True)
+        reported: list[str] = []
+
+        def launcher(post_message, _is_cancelled):
+            post_message(TranscriptChunk(segments=[_seg('x')]))
+            post_message(AudioWorkerStatus(status='stopped'))
+
+        session = HeadlessSession(controller, tmp_path, launcher, report=reported.append)
+        await session.run()
+
+        assert any('✗ digest failed' in line for line in reported)
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_emits_line(self, tmp_path: Path, default_template, fake_persistence, fake_llm):
+        import asyncio
+
+        controller = _controller(default_template, fake_persistence, fake_llm)
+        reported: list[str] = []
+        session = HeadlessSession(
+            controller, tmp_path, lambda *_: None, status_sink=reported.append, activity='recording'
+        )
+
+        beat = asyncio.create_task(session._heartbeat(0.01))  # noqa: SLF001 -- exercising the heartbeat loop
+        await asyncio.sleep(0.05)
+        beat.cancel()
+
+        assert any(line.startswith('⏺ recording') for line in reported)
+
+    @pytest.mark.asyncio
+    async def test_duplicate_warnings_deduped(self, tmp_path: Path, default_template, fake_persistence, fake_llm):
+        controller = _controller(default_template, fake_persistence, fake_llm)
+        reported: list[str] = []
+        warn = AudioWorkerStatus(status='warning', error='Audio signal lost: no sound from source')
+
+        def launcher(post_message, _is_cancelled):
+            post_message(warn)
+            post_message(warn)
+            post_message(warn)
+            post_message(AudioWorkerStatus(status='stopped'))
+
+        session = HeadlessSession(controller, tmp_path, launcher, report=reported.append)
+        await session.run()
+
+        assert sum('Audio signal lost' in line for line in reported) == 1
+
+    @pytest.mark.asyncio
+    async def test_warning_after_recovery_shown_again(
+        self, tmp_path: Path, default_template, fake_persistence, fake_llm
+    ):
+        controller = _controller(default_template, fake_persistence, fake_llm)
+        reported: list[str] = []
+        warn = AudioWorkerStatus(status='warning', error='Audio signal lost: no sound from source')
+
+        def launcher(post_message, _is_cancelled):
+            post_message(warn)
+            post_message(TranscriptChunk(segments=[_seg('audio is back')]))  # recovery
+            post_message(warn)
+            post_message(AudioWorkerStatus(status='stopped'))
+
+        session = HeadlessSession(controller, tmp_path, launcher, report=reported.append)
+        await session.run()
+
+        assert sum('Audio signal lost' in line for line in reported) == 2
+
+
+class _FakeStream:
+    def __init__(self, tty: bool):
+        self.buf = ''
+        self._tty = tty
+
+    def write(self, s: str) -> None:
+        self.buf += s
+
+    def flush(self) -> None:
+        pass
+
+    def isatty(self) -> bool:
+        return self._tty
+
+
+class TestStatusWriter:
+    def test_tty_status_in_place_then_commits_on_line(self):
+        from lazy_take_notes.l4_frameworks_and_drivers.headless import _StatusWriter  # noqa: PLC2701
+
+        stream = _FakeStream(tty=True)
+        writer = _StatusWriter(stream)
+
+        writer.status('⏺ 01:00')
+        assert stream.buf == '\r⏺ 01:00\x1b[K'
+
+        writer.status('⏺ 02:00')  # overwrites the same line in place
+        assert stream.buf == '\r⏺ 01:00\x1b[K\r⏺ 02:00\x1b[K'
+
+        stream.buf = ''
+        writer.line('✓ digest')  # commits the heartbeat snapshot (\n), then prints the line
+        assert stream.buf == '\n✓ digest\n'
+
+        stream.buf = ''
+        writer.status('⏺ 03:00')  # fresh in-place line
+        writer.finish()  # commits it on exit
+        assert stream.buf == '\r⏺ 03:00\x1b[K\n'
+
+    def test_non_tty_suppresses_status_and_uses_plain_lines(self):
+        from lazy_take_notes.l4_frameworks_and_drivers.headless import _StatusWriter  # noqa: PLC2701
+
+        stream = _FakeStream(tty=False)
+        writer = _StatusWriter(stream)
+
+        writer.status('⏺ 01:00')
+        assert not stream.buf  # heartbeat suppressed off-TTY
+
+        writer.line('✓ digest')
+        assert stream.buf == '✓ digest\n'
+
+        writer.finish()  # no-op
+        assert stream.buf == '✓ digest\n'
+
+
+class TestHeadlessTemplateSelection:
+    def _loader(self):
+        from lazy_take_notes.l3_interface_adapters.gateways.yaml_template_loader import YamlTemplateLoader
+
+        return YamlTemplateLoader()
+
+    def test_language_wins(self):
+        assert _select_headless_template(self._loader(), None, 'zh-TW').metadata.key == 'default_zh_tw'
+
+    def test_template_key(self):
+        assert _select_headless_template(self._loader(), 'sprint_retro_en', None).metadata.key == 'sprint_retro_en'
+
+    def test_default_when_nothing_given(self):
+        assert _select_headless_template(self._loader(), None, None).metadata.key == 'default_en'
+
+
+class TestHeadlessHelpers2:
+    def test_shared_worker_kwargs(self, default_template):
+        kw = _shared_worker_kwargs(build_app_config({}), default_template)
+        assert kw['language'] == default_template.metadata.locale.split('-')[0].lower()
+        assert 'chunk_duration' in kw
+        assert 'recognition_hints' in kw
+
+    def test_warn_missing_models(self, capsys):
+        _warn_missing_models(['digest-model'], ['action-model'])
+        err = capsys.readouterr().err
+        assert 'digest-model' in err
+        assert 'action-model' in err
+
+    def test_warn_missing_models_empty_is_silent(self, capsys):
+        _warn_missing_models([], [])
+        assert not capsys.readouterr().err
+
+
+class TestHeadlessFormatters:
+    def test_clock(self):
+        assert _clock(0) == '00:00'
+        assert _clock(65) == '01:05'
+        assert _clock(-5) == '00:00'
+
+    def test_heartbeat_line_pluralizes(self):
+        assert _heartbeat_line('recording', 60, 8, 1) == '⏺ recording · 01:00 · 8 seg · 1 digest'
+        assert _heartbeat_line('recording', 0, 0, 0) == '⏺ recording · 00:00 · 0 seg · 0 digests'
+
+    def test_banner_lines(self):
+        lines = _banner_lines('recording', Path('/x/sess'), 8123)
+        assert lines[0] == '▶ recording → /x/sess'
+        assert 'kill -INT 8123' in lines[1]
+        assert 'lazy-take-notes status' in lines[2]
+        assert not any('USR1' in line for line in lines)
+
+    def test_banner_lines_with_mute(self):
+        lines = _banner_lines('recording', Path('/x/sess'), 8123, show_mute=True)
+        assert any('kill -USR1 8123' in line for line in lines)
+
+    def test_summary_lines_includes_paths(self):
+        status = st.SessionStatus(
+            state=st.STOPPED,
+            pid=1,
+            started_at='2026-06-06T09:00:00',
+            updated_at='2026-06-06T09:12:30',
+            segment_count=45,
+            digest_count=3,
+        )
+        lines = _summary_lines(Path('/x/sess'), status)
+        assert lines[0] == '■ stopped · 12:30 · 45 seg · 3 digests'
+        assert any('transcript: /x/sess/transcript.txt' in line for line in lines)
+        assert any('notes:      /x/sess/notes.md' in line for line in lines)
+
+    def test_summary_lines_with_error(self):
+        status = st.SessionStatus(
+            state=st.ERROR,
+            pid=1,
+            started_at='2026-06-06T09:00:00',
+            updated_at='2026-06-06T09:00:03',
+            error='device gone',
+        )
+        lines = _summary_lines(Path('/x/sess'), status)
+        assert any('error:      device gone' in line for line in lines)
+
+    def test_summary_lines_minimal_when_empty(self):
+        status = st.SessionStatus(
+            state=st.STOPPED, pid=1, started_at='2026-06-06T09:00:00', updated_at='2026-06-06T09:00:05'
+        )
+        lines = _summary_lines(Path('/x/sess'), status)
+        assert lines == ['■ stopped · 00:05 · 0 seg · 0 digests']

--- a/tests/l4_frameworks_and_drivers/test_keep_awake.py
+++ b/tests/l4_frameworks_and_drivers/test_keep_awake.py
@@ -1,0 +1,48 @@
+"""Tests for the keep-awake (caffeinate) inhibitor."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from lazy_take_notes.l4_frameworks_and_drivers import keep_awake as ka
+
+
+class TestInhibitSleep:
+    def test_non_darwin_is_noop(self, monkeypatch):
+        monkeypatch.setattr(ka.sys, 'platform', 'linux')
+        assert ka.inhibit_sleep() is None
+
+    def test_darwin_spawns_caffeinate(self, monkeypatch):
+        monkeypatch.setattr(ka.sys, 'platform', 'darwin')
+        fake_popen = MagicMock(return_value='handle')
+        monkeypatch.setattr(ka.subprocess, 'Popen', fake_popen)
+
+        result = ka.inhibit_sleep()
+
+        assert result == 'handle'
+        args = fake_popen.call_args.args[0]
+        assert args[0] == 'caffeinate'
+        assert '-di' in args
+        # Own session so a terminal Ctrl-C can't kill the inhibitor mid-shutdown.
+        assert fake_popen.call_args.kwargs['start_new_session'] is True
+
+
+class TestReleaseSleep:
+    def test_none_is_noop(self):
+        ka.release_sleep(None)  # must not raise
+
+    def test_terminates_handle(self):
+        handle = MagicMock()
+        ka.release_sleep(handle)
+        handle.terminate.assert_called_once()
+
+
+class TestKeepAwakeContext:
+    def test_inhibits_then_releases(self, monkeypatch):
+        handle = MagicMock()
+        monkeypatch.setattr(ka, 'inhibit_sleep', lambda: handle)
+
+        with ka.keep_awake():
+            handle.terminate.assert_not_called()
+
+        handle.terminate.assert_called_once()


### PR DESCRIPTION
## Reason

Add a headless (no-TUI) path for live recording and file transcription so sessions can run detached or scripted, plus read-only CLI commands to browse saved sessions. Fixes a Ctrl-C `[Errno 32] Broken pipe` found while building it.

## Changes

1. **Session reader** (`gateways/session_reader.py`): read-only `list_sessions`/`latest_session`/`read_transcript`/`read_notes` port; the session picker now consumes it instead of its own logic.
2. **Headless runtime** (`headless.py`, `l1_entities/session_status.py`, `gateways/session_status.py`, `keep_awake.py`): asyncio runner over the existing audio/file workers, `.status.json` progress tracking, `caffeinate` keep-awake, a single in-place heartbeat line, recoverable-vs-fatal error handling, and a bounded clean stop.
3. **CLI** (`cli.py`, `cli_helpers.py`): `ls`/`transcript`/`notes`/`status` read commands; `--headless`/`--template`/`--language`/`--mute-mic` on `record`/`transcribe` (mutual-exclusion + mandatory-language guards).
4. **Ctrl-C fix** (`coreaudio_tap_source.py`, `subprocess_whisper_transcriber.py`): isolate the audio-tap and whisper child from the terminal's SIGINT so a stop winds down cleanly.

## Test Scope

- 1089 tests pass (+16 over base); new modules (`headless`, `keep_awake`, `session_status`, `session_reader`) at 100% line coverage.
- `prek` clean: ruff, ruff-format, ty (type check), import-linter (Clean Architecture contracts).
- Caveat: headless **live audio** capture is not exercised (no mic / screen-capture in CI); runtime is covered via fake-worker integration tests. macOS verified.

## Checks

- [x] Keep pull requests small so they can be easily reviewed