### PR TITLE
feat(l4): return notes path from run_transcribe/run_record

### DIFF
--- a/src/lazy_take_notes/l4_frameworks_and_drivers/cli_helpers.py
+++ b/src/lazy_take_notes/l4_frameworks_and_drivers/cli_helpers.py
@@ -14,6 +14,8 @@ from typing import TYPE_CHECKING
 
 import click
 
+from lazy_take_notes.l1_entities.session_files import NOTES
+
 if TYPE_CHECKING:
     from lazy_take_notes.l1_entities.transcript import TranscriptSegment
     from lazy_take_notes.l2_use_cases.ports.audio_source import AudioSource
@@ -192,7 +194,7 @@ def run_transcribe(
     transcriber: Transcriber | None = None,
     template_name: str | None = None,
     language: str | None = None,
-) -> None:
+) -> Path | None:
     """Run a complete transcription session — the high-level plugin entry point.
 
     Handles the entire flow: config loading → template picker → session
@@ -202,7 +204,9 @@ def run_transcribe(
     subtitle replay, or both (subtitle_segments takes priority, audio_path
     as fallback when segments are empty).
 
-    Returns normally if the user cancels the template picker.
+    Returns the notes file path the session produced, so callers (e.g. plugins)
+    can post-process it. Returns None if the user cancels the template picker or
+    no notes were written.
     """
     from lazy_take_notes.l4_frameworks_and_drivers.apps.transcribe import (  # noqa: PLC0415 -- deferred: Textual TUI not loaded for --help
         TranscribeApp,
@@ -219,7 +223,7 @@ def run_transcribe(
         template_loader, template_name=template_name, language=language, show_builtins=infra.show_builtin_templates
     )
     if template is None:
-        return
+        return None
 
     base_dir = resolve_base_dir(output_dir, config)
     out_dir = make_session_dir(base_dir, label)
@@ -251,6 +255,7 @@ def run_transcribe(
         label=label or '',
     )
     app.run()
+    return NOTES.resolve(out_dir)
 
 
 def preflight_microphone() -> None:
@@ -276,7 +281,7 @@ def run_record(
     template_name: str | None = None,
     language: str | None = None,
     mute_mic: bool = False,
-) -> None:
+) -> Path | None:
     """Run a live recording session -- the high-level plugin entry point.
 
     Handles the entire flow: config loading -> template picker -> session
@@ -285,6 +290,10 @@ def run_record(
 
     Plugin-supplied *llm_client*, *transcriber*, or *audio_source* override
     the defaults built by DependencyContainer.
+
+    Returns the notes file path the session produced, so callers (e.g. plugins)
+    can post-process it. Returns None if the user cancels the template picker or
+    no notes were written.
     """
     from lazy_take_notes.l4_frameworks_and_drivers.apps.record import (  # noqa: PLC0415 -- deferred: Textual TUI not loaded for --help
         RecordApp,
@@ -301,7 +310,7 @@ def run_record(
         template_loader, template_name=template_name, language=language, show_builtins=infra.show_builtin_templates
     )
     if template is None:
-        return
+        return None
 
     base_dir = resolve_base_dir(output_dir, config)
     out_dir = make_session_dir(base_dir, label)
@@ -340,3 +349,4 @@ def run_record(
 
     with keep_awake():
         app.run()
+    return NOTES.resolve(out_dir)

--- a/tests/l4_frameworks_and_drivers/test_cli.py
+++ b/tests/l4_frameworks_and_drivers/test_cli.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 import re
+from contextlib import ExitStack
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -1132,3 +1133,95 @@ class TestPluginCommands:
         assert result.exit_code == 0
         assert 'plugin-a' in result.output
         assert 'plugin-b' in result.output
+
+
+class TestSessionEntryPointsReturnNotesPath:
+    """run_transcribe / run_record hand the produced notes file back to callers."""
+
+    def _ctx(self, output_dir: Path) -> click.Context:
+        ctx = click.Context(click.Command('x'))
+        ctx.obj = {'config_path': None, 'output_dir': str(output_dir)}
+        return ctx
+
+    def _enter_common(self, stack: ExitStack, out_dir: Path) -> None:
+        infra = MagicMock(show_builtin_templates=True)
+        for cm in (
+            patch(f'{_CLI_HELPERS}.load_config', return_value=(MagicMock(), infra, MagicMock())),
+            patch(f'{_CLI_HELPERS}.select_template', return_value=MagicMock()),
+            patch(f'{_CLI_HELPERS}.make_session_dir', return_value=out_dir),
+            patch(f'{_CLI_HELPERS}.preflight_llm', return_value=([], [])),
+            patch('lazy_take_notes.l4_frameworks_and_drivers.container.DependencyContainer'),
+        ):
+            stack.enter_context(cm)
+
+    def test_run_transcribe_returns_notes_path_when_produced(self, tmp_path: Path):
+        from lazy_take_notes.l1_entities.session_files import NOTES
+        from lazy_take_notes.l4_frameworks_and_drivers.cli_helpers import run_transcribe
+
+        out_dir = tmp_path / 'session'
+        out_dir.mkdir()
+        notes = out_dir / NOTES.name
+        mock_app = MagicMock()
+        mock_app.run.side_effect = lambda: notes.write_text('# notes', encoding='utf-8')
+
+        with ExitStack() as stack:
+            self._enter_common(stack, out_dir)
+            stack.enter_context(
+                patch('lazy_take_notes.l4_frameworks_and_drivers.apps.transcribe.TranscribeApp', return_value=mock_app)
+            )
+            result = run_transcribe(self._ctx(tmp_path))
+
+        assert result == notes
+
+    def test_run_transcribe_returns_none_when_no_notes_written(self, tmp_path: Path):
+        from lazy_take_notes.l4_frameworks_and_drivers.cli_helpers import run_transcribe
+
+        out_dir = tmp_path / 'session'
+        out_dir.mkdir()
+
+        with ExitStack() as stack:
+            self._enter_common(stack, out_dir)
+            stack.enter_context(
+                patch(
+                    'lazy_take_notes.l4_frameworks_and_drivers.apps.transcribe.TranscribeApp',
+                    return_value=MagicMock(),
+                )
+            )
+            result = run_transcribe(self._ctx(tmp_path))
+
+        assert result is None
+
+    def test_run_transcribe_returns_none_on_template_cancel(self, tmp_path: Path):
+        from lazy_take_notes.l4_frameworks_and_drivers.cli_helpers import run_transcribe
+
+        with (
+            patch(
+                f'{_CLI_HELPERS}.load_config',
+                return_value=(MagicMock(), MagicMock(show_builtin_templates=True), MagicMock()),
+            ),
+            patch(f'{_CLI_HELPERS}.select_template', return_value=None),
+        ):
+            result = run_transcribe(self._ctx(tmp_path))
+
+        assert result is None
+
+    def test_run_record_returns_notes_path_when_produced(self, tmp_path: Path):
+        from lazy_take_notes.l1_entities.session_files import NOTES
+        from lazy_take_notes.l4_frameworks_and_drivers.cli_helpers import run_record
+
+        out_dir = tmp_path / 'session'
+        out_dir.mkdir()
+        notes = out_dir / NOTES.name
+        mock_app = MagicMock()
+        mock_app.run.side_effect = lambda: notes.write_text('# notes', encoding='utf-8')
+
+        with ExitStack() as stack:
+            self._enter_common(stack, out_dir)
+            stack.enter_context(patch(f'{_CLI_HELPERS}.preflight_microphone'))
+            stack.enter_context(patch('lazy_take_notes.l4_frameworks_and_drivers.keep_awake.keep_awake'))
+            stack.enter_context(
+                patch('lazy_take_notes.l4_frameworks_and_drivers.apps.record.RecordApp', return_value=mock_app)
+            )
+            result = run_record(self._ctx(tmp_path))
+
+        assert result == notes


### PR DESCRIPTION
## Reason

Plugins that drive a session through `plugin_api` (e.g. ltn-youtube) need to find the notes file afterward to post-process it — rewriting `[HH:MM:SS]` timestamps into source-linked deep links, prepending a source header, etc. Today both entry points return `None`, and the session directory is created internally by `make_session_dir` with a `datetime.now()` timestamp the caller can't predict. So a plugin has no reliable way to locate what was written.

This keeps the YouTube-specific link logic (`?t=`/`&t=SECONDS`) in the YouTube plugin where it belongs, instead of leaking it into the core's generic templates.

## Changes

- `run_transcribe` and `run_record` now return `Path | None` instead of `None`.
- They return `NOTES.resolve(out_dir)` — the produced notes file (`notes.md`, or the legacy `digest.md`), or `None` when the session is cancelled or wrote no notes.
- Using `NOTES.resolve()` keeps the filename and legacy-name fallback owned by the core; callers stay dumb.

Headless entry points (`run_transcribe_headless` / `run_record_headless`) are intentionally untouched: they already echo `out_dir` to stdout and aren't exported from `plugin_api`, so no consumer needs a return value there.

## Test Scope

- 4 new tests in `TestSessionEntryPointsReturnNotesPath` (test_cli.py): notes produced → path, no notes → None, template cancel → None, and the record path.
- Full suite green (1093 passed), ruff + ty + import-linter clean.